### PR TITLE
Add webhook message processing

### DIFF
--- a/bot/src/main/java/com/whatsbot/controller/WebhookController.java
+++ b/bot/src/main/java/com/whatsbot/controller/WebhookController.java
@@ -1,0 +1,50 @@
+package com.whatsbot.controller;
+
+import com.whatsbot.dto.webhook.WebhookRequestDto;
+import com.whatsbot.dto.webhook.EntryDto;
+import com.whatsbot.dto.webhook.ChangeDto;
+import com.whatsbot.dto.webhook.ValueDto;
+import com.whatsbot.dto.webhook.WhatsappMessageDto;
+import com.whatsbot.service.MessageProcessorService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RestController
+@RequestMapping("/webhook")
+@RequiredArgsConstructor
+public class WebhookController {
+
+    private static final Logger log = LoggerFactory.getLogger(WebhookController.class);
+
+    private final MessageProcessorService messageProcessorService;
+
+    @PostMapping("/receive")
+    public ResponseEntity<Void> receive(@Valid @RequestBody WebhookRequestDto request) {
+        if (request.getEntry() != null) {
+            for (EntryDto entry : request.getEntry()) {
+                if (entry.getChanges() != null) {
+                    for (ChangeDto change : entry.getChanges()) {
+                        ValueDto value = change.getValue();
+                        if (value != null && value.getMessages() != null) {
+                            for (WhatsappMessageDto msg : value.getMessages()) {
+                                String sender = msg.getFrom();
+                                String body = msg.getText() != null ? msg.getText().getBody() : null;
+                                log.info("Received message from {}: {}", sender, body);
+                                messageProcessorService.processIncomingMessage(sender, body);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return ResponseEntity.ok().build();
+    }
+}

--- a/bot/src/main/java/com/whatsbot/dto/webhook/ChangeDto.java
+++ b/bot/src/main/java/com/whatsbot/dto/webhook/ChangeDto.java
@@ -1,0 +1,16 @@
+package com.whatsbot.dto.webhook;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+@Data
+public class ChangeDto {
+    @NotBlank
+    private String field;
+
+    @NotNull
+    @Valid
+    private ValueDto value;
+}

--- a/bot/src/main/java/com/whatsbot/dto/webhook/ContactDto.java
+++ b/bot/src/main/java/com/whatsbot/dto/webhook/ContactDto.java
@@ -1,0 +1,14 @@
+package com.whatsbot.dto.webhook;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class ContactDto {
+    @NotBlank
+    private String wa_id;
+
+    @Valid
+    private ProfileDto profile;
+}

--- a/bot/src/main/java/com/whatsbot/dto/webhook/EntryDto.java
+++ b/bot/src/main/java/com/whatsbot/dto/webhook/EntryDto.java
@@ -1,0 +1,18 @@
+package com.whatsbot.dto.webhook;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class EntryDto {
+    @NotBlank
+    private String id;
+
+    @NotEmpty
+    @Valid
+    private List<ChangeDto> changes;
+}

--- a/bot/src/main/java/com/whatsbot/dto/webhook/ProfileDto.java
+++ b/bot/src/main/java/com/whatsbot/dto/webhook/ProfileDto.java
@@ -1,0 +1,10 @@
+package com.whatsbot.dto.webhook;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class ProfileDto {
+    @NotBlank
+    private String name;
+}

--- a/bot/src/main/java/com/whatsbot/dto/webhook/ValueDto.java
+++ b/bot/src/main/java/com/whatsbot/dto/webhook/ValueDto.java
@@ -1,0 +1,15 @@
+package com.whatsbot.dto.webhook;
+
+import jakarta.validation.Valid;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class ValueDto {
+    @Valid
+    private List<ContactDto> contacts;
+
+    @Valid
+    private List<WhatsappMessageDto> messages;
+}

--- a/bot/src/main/java/com/whatsbot/dto/webhook/WebhookRequestDto.java
+++ b/bot/src/main/java/com/whatsbot/dto/webhook/WebhookRequestDto.java
@@ -1,0 +1,18 @@
+package com.whatsbot.dto.webhook;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class WebhookRequestDto {
+    @NotBlank
+    private String object;
+
+    @NotEmpty
+    @Valid
+    private List<EntryDto> entry;
+}

--- a/bot/src/main/java/com/whatsbot/dto/webhook/WhatsappMessageDto.java
+++ b/bot/src/main/java/com/whatsbot/dto/webhook/WhatsappMessageDto.java
@@ -1,0 +1,14 @@
+package com.whatsbot.dto.webhook;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class WhatsappMessageDto {
+    @NotBlank
+    private String from;
+
+    @Valid
+    private WhatsappTextDto text;
+}

--- a/bot/src/main/java/com/whatsbot/dto/webhook/WhatsappTextDto.java
+++ b/bot/src/main/java/com/whatsbot/dto/webhook/WhatsappTextDto.java
@@ -1,0 +1,10 @@
+package com.whatsbot.dto.webhook;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class WhatsappTextDto {
+    @NotBlank
+    private String body;
+}

--- a/bot/src/main/java/com/whatsbot/intent/IntentClassifier.java
+++ b/bot/src/main/java/com/whatsbot/intent/IntentClassifier.java
@@ -1,0 +1,47 @@
+package com.whatsbot.intent;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+/**
+ * Simple classifier mapping common Italian phrases to intents.
+ */
+public class IntentClassifier {
+
+    private final Map<Pattern, IntentType> patternMap = new LinkedHashMap<>();
+
+    public IntentClassifier() {
+        patternMap.put(Pattern.compile("(?i)\\b(voglio\\s+prenotare|prenotare|vorrei\\s+prenotare)\\b"), IntentType.BOOKING);
+        patternMap.put(Pattern.compile("(?i)\\b(annulla\\s+visita|cancella\\s+prenotazione|annullare\\s+prenotazione)\\b"), IntentType.CANCEL);
+        patternMap.put(Pattern.compile("(?i)\\b(orari\\s+di\\s+apertura|quando\\s+siete\\s+aperti|orario\\s+di\\s+apertura)\\b"), IntentType.INFO);
+    }
+
+    /**
+     * Classify the incoming text into an intent.
+     *
+     * @param text user input
+     * @return detected intent or GENERIC if no pattern matches
+     */
+    public IntentType classify(String text) {
+        if (text == null || text.isBlank()) {
+            return IntentType.GENERIC;
+        }
+        for (Map.Entry<Pattern, IntentType> entry : patternMap.entrySet()) {
+            if (entry.getKey().matcher(text).find()) {
+                return entry.getValue();
+            }
+        }
+        return IntentType.GENERIC;
+    }
+
+    /**
+     * Allows to register additional patterns dynamically.
+     *
+     * @param regex regex pattern to match
+     * @param intent intent associated with the pattern
+     */
+    public void addPattern(String regex, IntentType intent) {
+        patternMap.put(Pattern.compile(regex, Pattern.CASE_INSENSITIVE), intent);
+    }
+}

--- a/bot/src/main/java/com/whatsbot/intent/IntentType.java
+++ b/bot/src/main/java/com/whatsbot/intent/IntentType.java
@@ -1,0 +1,8 @@
+package com.whatsbot.intent;
+
+public enum IntentType {
+    BOOKING,
+    INFO,
+    CANCEL,
+    GENERIC
+}

--- a/bot/src/main/java/com/whatsbot/service/MessageProcessorService.java
+++ b/bot/src/main/java/com/whatsbot/service/MessageProcessorService.java
@@ -1,0 +1,5 @@
+package com.whatsbot.service;
+
+public interface MessageProcessorService {
+    void processIncomingMessage(String sender, String message);
+}

--- a/bot/src/main/java/com/whatsbot/service/impl/MessageProcessorServiceImpl.java
+++ b/bot/src/main/java/com/whatsbot/service/impl/MessageProcessorServiceImpl.java
@@ -1,0 +1,26 @@
+package com.whatsbot.service.impl;
+
+import com.whatsbot.dto.MessageDto;
+import com.whatsbot.service.MessageProcessorService;
+import com.whatsbot.service.MessageService;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MessageProcessorServiceImpl implements MessageProcessorService {
+
+    private static final Logger log = LoggerFactory.getLogger(MessageProcessorServiceImpl.class);
+
+    private final MessageService messageService;
+
+    @Override
+    public void processIncomingMessage(String sender, String message) {
+        MessageDto dto = new MessageDto();
+        dto.setText(message);
+        MessageDto saved = messageService.save(dto);
+        log.info("Processed message from {} with saved id {}", sender, saved.getId());
+    }
+}


### PR DESCRIPTION
## Summary
- create DTOs for webhook payload
- add MessageProcessorService to handle incoming messages
- implement a webhook controller to receive WhatsApp messages
- add Intent classifier with regex matching

## Testing
- `mvn -q -pl bot test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854323db750832a9cdc7c4b48c09233