### PR TITLE
Fix stray EOF in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@ target/
 # Node / React
 node_modules/
 build/
-EOF


### PR DESCRIPTION
## Summary
- clean up `.gitignore` to remove leftover `EOF`

## Testing
- `mvn -q test` *(fails: command not found)*
- `npm test` *(fails: missing script and network access)*

------
https://chatgpt.com/codex/tasks/task_e_685587f90f10832a9ebab968db80c796