### PR TITLE
Inject RestTemplate via configuration

### DIFF
--- a/bot/src/main/java/com/whatsbot/config/RestTemplateConfig.java
+++ b/bot/src/main/java/com/whatsbot/config/RestTemplateConfig.java
@@ -1,0 +1,15 @@
+package com.whatsbot.config;
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate(RestTemplateBuilder builder) {
+        return builder.build();
+    }
+}

--- a/bot/src/main/java/com/whatsbot/service/WhatsAppSenderService.java
+++ b/bot/src/main/java/com/whatsbot/service/WhatsAppSenderService.java
@@ -18,7 +18,7 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class WhatsAppSenderService {
     private static final Logger LOGGER = LoggerFactory.getLogger(WhatsAppSenderService.class);
-    private final RestTemplate restTemplate = new RestTemplate();
+    private final RestTemplate restTemplate;
     private final WhatsAppProperties properties;
     private final MessageAuditService messageAuditService;
 


### PR DESCRIPTION
## Summary
- create a `RestTemplateConfig` configuration providing a `RestTemplate` bean
- inject the `RestTemplate` bean in `WhatsAppSenderService`

## Testing
- `mvn -q -pl bot test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6855880d0e24832a95de67ba9f299088