### PR TITLE
Configure frontend dev proxy

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -5,5 +5,11 @@ export default defineConfig({
   plugins: [react()],
   server: {
     port: 3000,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8080',
+        changeOrigin: true,
+      },
+    },
   },
 });


### PR DESCRIPTION
## Summary
- update Vite configuration to proxy `/api` calls to the local backend

## Testing
- `npm run build` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_6855881d09fc832a88525b09b0fdc6df