### PR TITLE
Configure CORS origins from YAML

### DIFF
--- a/bot/src/main/java/com/whatsbot/config/CorsProperties.java
+++ b/bot/src/main/java/com/whatsbot/config/CorsProperties.java
@@ -8,5 +8,9 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(prefix = "cors")
 public class CorsProperties {
     private boolean enabled = false;
-    private List<String> allowedOrigins = List.of("*");
+    /**
+     * Explicitly allowed origins for CORS. Empty by default to avoid
+     * permissive configuration.
+     */
+    private List<String> allowedOrigins = List.of();
 }

--- a/bot/src/main/resources/application.yml
+++ b/bot/src/main/resources/application.yml
@@ -27,5 +27,5 @@ whatsapp:
 cors:
   enabled: true
   allowed-origins:
-    - "*"
+    - "http://localhost:3000"
  


### PR DESCRIPTION
## Summary
- avoid permissive wildcard in `CorsProperties`
- set example allowed origins in `application.yml`

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_68558816fbb8832a837c88f7e21d7e13