### PR TITLE
Add user and template controllers

### DIFF
--- a/bot/src/main/java/com/whatsbot/controller/TemplateController.java
+++ b/bot/src/main/java/com/whatsbot/controller/TemplateController.java
@@ -1,0 +1,23 @@
+package com.whatsbot.controller;
+
+import com.whatsbot.dto.TemplateSendRequest;
+import com.whatsbot.service.TemplateService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import jakarta.validation.Valid;
+
+@RestController
+@RequestMapping("/api/template")
+@RequiredArgsConstructor
+public class TemplateController {
+
+    private final TemplateService templateService;
+
+    @PostMapping("/send")
+    public ResponseEntity<Void> send(@Valid @RequestBody TemplateSendRequest request) {
+        templateService.sendTemplate(request.getUserId(), request.getTemplateName());
+        return ResponseEntity.accepted().build();
+    }
+}

--- a/bot/src/main/java/com/whatsbot/controller/UserController.java
+++ b/bot/src/main/java/com/whatsbot/controller/UserController.java
@@ -1,0 +1,28 @@
+package com.whatsbot.controller;
+
+import com.whatsbot.dto.MessageHistoryDto;
+import com.whatsbot.dto.UserDto;
+import com.whatsbot.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @GetMapping
+    public List<UserDto> getAll() {
+        return userService.findAll();
+    }
+
+    @GetMapping("/{id}/messages")
+    public List<MessageHistoryDto> getMessages(@PathVariable UUID id) {
+        return userService.getMessages(id);
+    }
+}

--- a/bot/src/main/java/com/whatsbot/dto/MessageHistoryDto.java
+++ b/bot/src/main/java/com/whatsbot/dto/MessageHistoryDto.java
@@ -1,0 +1,16 @@
+package com.whatsbot.dto;
+
+import com.whatsbot.model.MessageDirection;
+import lombok.Data;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Data
+public class MessageHistoryDto {
+    private UUID id;
+    private UUID userId;
+    private String text;
+    private MessageDirection direction;
+    private Instant timestamp;
+}

--- a/bot/src/main/java/com/whatsbot/dto/TemplateSendRequest.java
+++ b/bot/src/main/java/com/whatsbot/dto/TemplateSendRequest.java
@@ -1,0 +1,15 @@
+package com.whatsbot.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+import java.util.UUID;
+
+@Data
+public class TemplateSendRequest {
+    @NotNull
+    private UUID userId;
+    @NotBlank
+    private String templateName;
+}

--- a/bot/src/main/java/com/whatsbot/dto/UserDto.java
+++ b/bot/src/main/java/com/whatsbot/dto/UserDto.java
@@ -1,0 +1,13 @@
+package com.whatsbot.dto;
+
+import lombok.Data;
+
+import java.util.UUID;
+
+@Data
+public class UserDto {
+    private UUID id;
+    private String phone;
+    private String name;
+    private String lastMessage;
+}

--- a/bot/src/main/java/com/whatsbot/repository/MessageRepository.java
+++ b/bot/src/main/java/com/whatsbot/repository/MessageRepository.java
@@ -4,8 +4,12 @@ import com.whatsbot.model.Message;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 @Repository
 public interface MessageRepository extends JpaRepository<Message, UUID> {
+    List<Message> findByUser_IdOrderByTimestampAsc(UUID userId);
+    Optional<Message> findFirstByUser_IdOrderByTimestampDesc(UUID userId);
 }

--- a/bot/src/main/java/com/whatsbot/service/TemplateService.java
+++ b/bot/src/main/java/com/whatsbot/service/TemplateService.java
@@ -1,0 +1,7 @@
+package com.whatsbot.service;
+
+import java.util.UUID;
+
+public interface TemplateService {
+    void sendTemplate(UUID userId, String templateName);
+}

--- a/bot/src/main/java/com/whatsbot/service/UserService.java
+++ b/bot/src/main/java/com/whatsbot/service/UserService.java
@@ -1,0 +1,12 @@
+package com.whatsbot.service;
+
+import com.whatsbot.dto.MessageHistoryDto;
+import com.whatsbot.dto.UserDto;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface UserService {
+    List<UserDto> findAll();
+    List<MessageHistoryDto> getMessages(UUID userId);
+}

--- a/bot/src/main/java/com/whatsbot/service/impl/TemplateServiceImpl.java
+++ b/bot/src/main/java/com/whatsbot/service/impl/TemplateServiceImpl.java
@@ -1,0 +1,37 @@
+package com.whatsbot.service.impl;
+
+import com.whatsbot.model.Message;
+import com.whatsbot.model.MessageDirection;
+import com.whatsbot.model.User;
+import com.whatsbot.repository.MessageRepository;
+import com.whatsbot.repository.UserRepository;
+import com.whatsbot.service.TemplateService;
+import com.whatsbot.service.WhatsAppSenderService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class TemplateServiceImpl implements TemplateService {
+
+    private final UserRepository userRepository;
+    private final MessageRepository messageRepository;
+    private final WhatsAppSenderService whatsAppSenderService;
+
+    @Override
+    public void sendTemplate(UUID userId, String templateName) {
+        User user = userRepository.findById(userId)
+                .orElseThrow();
+        Message message = new Message();
+        message.setUser(user);
+        message.setText(templateName);
+        message.setDirection(MessageDirection.OUT);
+        message.setIntent("TEMPLATE");
+        Message saved = messageRepository.save(message);
+
+        whatsAppSenderService.sendTemplateMessage(saved.getId(), user.getPhone(), templateName, "TEMPLATE", Map.of());
+    }
+}

--- a/bot/src/main/java/com/whatsbot/service/impl/UserServiceImpl.java
+++ b/bot/src/main/java/com/whatsbot/service/impl/UserServiceImpl.java
@@ -1,0 +1,50 @@
+package com.whatsbot.service.impl;
+
+import com.whatsbot.dto.MessageHistoryDto;
+import com.whatsbot.dto.UserDto;
+import com.whatsbot.repository.MessageRepository;
+import com.whatsbot.repository.UserRepository;
+import com.whatsbot.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class UserServiceImpl implements UserService {
+
+    private final UserRepository userRepository;
+    private final MessageRepository messageRepository;
+
+    @Override
+    public List<UserDto> findAll() {
+        return userRepository.findAll().stream()
+                .map(u -> {
+                    UserDto dto = new UserDto();
+                    dto.setId(u.getId());
+                    dto.setPhone(u.getPhone());
+                    dto.setName(u.getName());
+                    messageRepository.findFirstByUser_IdOrderByTimestampDesc(u.getId())
+                            .ifPresent(m -> dto.setLastMessage(m.getText()));
+                    return dto;
+                })
+                .toList();
+    }
+
+    @Override
+    public List<MessageHistoryDto> getMessages(UUID userId) {
+        return messageRepository.findByUser_IdOrderByTimestampAsc(userId).stream()
+                .map(m -> {
+                    MessageHistoryDto dto = new MessageHistoryDto();
+                    dto.setId(m.getId());
+                    dto.setUserId(userId);
+                    dto.setText(m.getText());
+                    dto.setDirection(m.getDirection());
+                    dto.setTimestamp(m.getTimestamp());
+                    return dto;
+                })
+                .toList();
+    }
+}


### PR DESCRIPTION
## Summary
- provide endpoints for listing users and fetching user message history
- add template send flow via new controller
- define DTOs for user list, message history and template sending
- extend repositories and services to support new operations

## Testing
- `mvn -q -pl bot -am test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855880f3b8c832aac754e8f3f461650