### PR TITLE
Add Docker Compose setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,14 @@ Sistema leggero di classificazione intent tramite regex o chiamate a HuggingFace
 - Nessuna logica hardcoded nei controller
 - Repository solo con Spring Data
 - Testabili facilmente con JUnit + Mockito
+## 🚀 Avvio con Docker Compose
+
+Esegui tutti i servizi tramite:
+
+```bash
+docker-compose up --build
+```
+
 
 ## 📣 Prompt per Codex / GPT
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,14 @@
+# Build stage
+FROM maven:3.9.6-eclipse-temurin-21 AS builder
+WORKDIR /app
+COPY pom.xml ./
+COPY bot/pom.xml ./bot/pom.xml
+COPY bot/src ./bot/src
+RUN mvn -B -pl bot -am package
+
+# Runtime stage
+FROM eclipse-temurin:21-jre
+WORKDIR /app
+COPY --from=builder /app/bot/target/bot-*.jar app.jar
+EXPOSE 8080
+ENTRYPOINT ["java","-jar","app.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,48 @@
+version: '3.9'
+
+services:
+  # Database PostgreSQL
+  postgres:
+    image: postgres:15
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: whatsapp_bot
+      POSTGRES_USER: admin
+      POSTGRES_PASSWORD: admin
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+    networks:
+      - whatsapp-net
+
+  # Backend Spring Boot service
+  backend:
+    build:
+      context: ./backend
+    depends_on:
+      - postgres
+    ports:
+      - "8080:8080"
+    networks:
+      - whatsapp-net
+
+  # Opzionale: expose backend via Ngrok
+  ngrok:
+    image: ngrok/ngrok:latest
+    depends_on:
+      - backend
+    command: "tcp 8080"
+    environment:
+      NGROK_AUTHTOKEN: ${NGROK_AUTHTOKEN}
+    networks:
+      - whatsapp-net
+    # Visualizza i log nel terminale
+    tty: true
+
+volumes:
+  postgres-data:
+
+networks:
+  whatsapp-net:
+    external: false


### PR DESCRIPTION
## Summary
- add Dockerfile for backend service
- add docker-compose.yml with PostgreSQL, backend and optional ngrok
- document Docker Compose usage in README

## Testing
- `mvn -f bot/pom.xml -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68559030ef44832abbf01c0e77d5a753