### PR TITLE
Supporto webhook Twilio

### DIFF
--- a/backend/bot/pom.xml
+++ b/backend/bot/pom.xml
@@ -44,6 +44,11 @@
             <version>${lombok.version}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>com.twilio.sdk</groupId>
+            <artifactId>twilio</artifactId>
+            <version>8.34.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/backend/bot/src/main/java/com/whatsbot/config/WebhookProperties.java
+++ b/backend/bot/src/main/java/com/whatsbot/config/WebhookProperties.java
@@ -8,4 +8,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class WebhookProperties {
     /** Token used to authorize incoming webhook requests */
     private String token;
+
+    /** Auth token used to validate Twilio webhook signatures */
+    private String twilioAuthToken;
 }

--- a/backend/bot/src/main/java/com/whatsbot/controller/WebhookController.java
+++ b/backend/bot/src/main/java/com/whatsbot/controller/WebhookController.java
@@ -1,28 +1,25 @@
 package com.whatsbot.controller;
 
-import com.whatsbot.dto.webhook.WebhookRequestDto;
-import com.whatsbot.dto.webhook.EntryDto;
-import com.whatsbot.dto.webhook.ChangeDto;
-import com.whatsbot.dto.webhook.ValueDto;
-import com.whatsbot.dto.webhook.WhatsappMessageDto;
-import com.whatsbot.service.MessageProcessorService;
+import com.twilio.security.RequestValidator;
 import com.whatsbot.config.WebhookProperties;
-import jakarta.validation.Valid;
+import com.whatsbot.service.MessageProcessorService;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
-
+@RequiredArgsConstructor
 @RestController
 @RequestMapping("/webhook")
-@RequiredArgsConstructor
 public class WebhookController {
 
     private static final Logger log = LoggerFactory.getLogger(WebhookController.class);
@@ -30,31 +27,27 @@ public class WebhookController {
     private final MessageProcessorService messageProcessorService;
     private final WebhookProperties webhookProperties;
 
-    @PostMapping("/receive")
-    public ResponseEntity<Void> receive(
-            @RequestHeader(value = "X-Webhook-Token", required = false) String token,
-            @Valid @RequestBody WebhookRequestDto request) {
-        if (token == null || !token.equals(webhookProperties.getToken())) {
-            log.warn("Unauthorized webhook request");
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+    @PostMapping(
+            path = "/receive",
+            consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE,
+            produces = MediaType.APPLICATION_JSON_VALUE
+    )
+    public ResponseEntity<String> receiveWebhook(
+            @RequestHeader("X-Twilio-Signature") String signature,
+            @RequestParam MultiValueMap<String, String> formParams
+    ) {
+        String url = ServletUriComponentsBuilder.fromCurrentRequest().build().toUriString();
+        RequestValidator validator = new RequestValidator(webhookProperties.getTwilioAuthToken());
+        if (!validator.validate(url, formParams.toSingleValueMap(), signature)) {
+            log.warn("Invalid Twilio signature");
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("{}");
         }
-        if (request.getEntry() != null) {
-            for (EntryDto entry : request.getEntry()) {
-                if (entry.getChanges() != null) {
-                    for (ChangeDto change : entry.getChanges()) {
-                        ValueDto value = change.getValue();
-                        if (value != null && value.getMessages() != null) {
-                            for (WhatsappMessageDto msg : value.getMessages()) {
-                                String sender = msg.getFrom();
-                                String body = msg.getText() != null ? msg.getText().getBody() : null;
-                                log.info("Received message from {}: {}", sender, body);
-                                messageProcessorService.processIncomingMessage(sender, body);
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        return ResponseEntity.ok().build();
+
+        String from = formParams.getFirst("From");
+        String body = formParams.getFirst("Body");
+        String sid = formParams.getFirst("MessageSid");
+        log.info("Received Twilio message {} from {}", sid, from);
+        messageProcessorService.processIncomingMessage(from, body);
+        return ResponseEntity.ok("{}");
     }
 }

--- a/backend/bot/src/main/resources/application.yml
+++ b/backend/bot/src/main/resources/application.yml
@@ -26,6 +26,7 @@ whatsapp:
 
 webhook:
   token: CHANGE_ME
+  twilio-auth-token: YOUR_TWILIO_AUTH_TOKEN
 
 cors:
   enabled: true


### PR DESCRIPTION
## Summary
- abilita il consumo `application/x-www-form-urlencoded` per `/webhook/receive`
- verifica la firma con `RequestValidator` di Twilio
- estrai i parametri e passa il messaggio al service
- aggiungi l'auth token Twilio tra le proprietà
- dipendenza Maven per Twilio SDK

## Testing
- `mvn test` *(fallita: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685675a295d0832a9d9fa7d4a6c60cc3