### PR TITLE
Add conversational flow module

### DIFF
--- a/backend/bot/pom.xml
+++ b/backend/bot/pom.xml
@@ -53,6 +53,10 @@
             <artifactId>twilio</artifactId>
             <version>8.34.0</version>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-yaml</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/backend/bot/src/main/java/com/whatsbot/controller/FlowController.java
+++ b/backend/bot/src/main/java/com/whatsbot/controller/FlowController.java
@@ -1,0 +1,31 @@
+package com.whatsbot.controller;
+
+import com.whatsbot.dto.FlowStepRequest;
+import com.whatsbot.dto.FlowStepResponse;
+import com.whatsbot.service.ConversationalFlowService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/flows")
+@RequiredArgsConstructor
+public class FlowController {
+
+    private final ConversationalFlowService flowService;
+
+    @GetMapping
+    public List<String> listFlows() {
+        return flowService.listFlows();
+    }
+
+    @PostMapping("/{flowId}/step")
+    public ResponseEntity<FlowStepResponse> nextStep(@PathVariable String flowId,
+                                                     @Valid @RequestBody FlowStepRequest request) {
+        return new ResponseEntity<>(flowService.nextStep(flowId, request), HttpStatus.OK);
+    }
+}

--- a/backend/bot/src/main/java/com/whatsbot/dto/FlowStepRequest.java
+++ b/backend/bot/src/main/java/com/whatsbot/dto/FlowStepRequest.java
@@ -1,0 +1,15 @@
+package com.whatsbot.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+import java.util.Map;
+import java.util.UUID;
+
+@Data
+public class FlowStepRequest {
+    @NotNull
+    private UUID userId;
+    private String intent;
+    private Map<String, String> params;
+}

--- a/backend/bot/src/main/java/com/whatsbot/dto/FlowStepResponse.java
+++ b/backend/bot/src/main/java/com/whatsbot/dto/FlowStepResponse.java
@@ -1,0 +1,9 @@
+package com.whatsbot.dto;
+
+import lombok.Data;
+
+@Data
+public class FlowStepResponse {
+    private String step;
+    private String message;
+}

--- a/backend/bot/src/main/java/com/whatsbot/flow/FlowDefinition.java
+++ b/backend/bot/src/main/java/com/whatsbot/flow/FlowDefinition.java
@@ -1,0 +1,11 @@
+package com.whatsbot.flow;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class FlowDefinition {
+    private String id;
+    private List<FlowStep> steps;
+}

--- a/backend/bot/src/main/java/com/whatsbot/flow/FlowStep.java
+++ b/backend/bot/src/main/java/com/whatsbot/flow/FlowStep.java
@@ -1,0 +1,12 @@
+package com.whatsbot.flow;
+
+import lombok.Data;
+
+import java.util.Map;
+
+@Data
+public class FlowStep {
+    private String id;
+    private String message;
+    private Map<String, String> transitions;
+}

--- a/backend/bot/src/main/java/com/whatsbot/flow/FlowsConfig.java
+++ b/backend/bot/src/main/java/com/whatsbot/flow/FlowsConfig.java
@@ -1,0 +1,10 @@
+package com.whatsbot.flow;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class FlowsConfig {
+    private List<FlowDefinition> flows;
+}

--- a/backend/bot/src/main/java/com/whatsbot/model/ConversationState.java
+++ b/backend/bot/src/main/java/com/whatsbot/model/ConversationState.java
@@ -1,0 +1,44 @@
+package com.whatsbot.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "conversation_state")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ConversationState {
+
+    @Id
+    @GeneratedValue
+    private UUID id;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Column(name = "flow_id", nullable = false)
+    private String flowId;
+
+    @Column(nullable = false)
+    private String step;
+
+    @Lob
+    private String data;
+
+    @CreationTimestamp
+    private Instant createdAt;
+
+    @UpdateTimestamp
+    private Instant updatedAt;
+}

--- a/backend/bot/src/main/java/com/whatsbot/repository/ConversationStateRepository.java
+++ b/backend/bot/src/main/java/com/whatsbot/repository/ConversationStateRepository.java
@@ -1,0 +1,13 @@
+package com.whatsbot.repository;
+
+import com.whatsbot.model.ConversationState;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface ConversationStateRepository extends JpaRepository<ConversationState, UUID> {
+    Optional<ConversationState> findByUser_IdAndFlowId(UUID userId, String flowId);
+}

--- a/backend/bot/src/main/java/com/whatsbot/service/ConversationalFlowService.java
+++ b/backend/bot/src/main/java/com/whatsbot/service/ConversationalFlowService.java
@@ -1,0 +1,11 @@
+package com.whatsbot.service;
+
+import com.whatsbot.dto.FlowStepRequest;
+import com.whatsbot.dto.FlowStepResponse;
+
+import java.util.List;
+
+public interface ConversationalFlowService {
+    List<String> listFlows();
+    FlowStepResponse nextStep(String flowId, FlowStepRequest request);
+}

--- a/backend/bot/src/main/java/com/whatsbot/service/impl/ConversationalFlowServiceImpl.java
+++ b/backend/bot/src/main/java/com/whatsbot/service/impl/ConversationalFlowServiceImpl.java
@@ -1,0 +1,105 @@
+package com.whatsbot.service.impl;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.whatsbot.dto.FlowStepRequest;
+import com.whatsbot.dto.FlowStepResponse;
+import com.whatsbot.flow.FlowDefinition;
+import com.whatsbot.flow.FlowStep;
+import com.whatsbot.flow.FlowsConfig;
+import com.whatsbot.model.ConversationState;
+import com.whatsbot.model.User;
+import com.whatsbot.repository.ConversationStateRepository;
+import com.whatsbot.repository.UserRepository;
+import com.whatsbot.service.ConversationalFlowService;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.util.*;
+
+@Service
+@RequiredArgsConstructor
+public class ConversationalFlowServiceImpl implements ConversationalFlowService {
+
+    private static final Logger log = LoggerFactory.getLogger(ConversationalFlowServiceImpl.class);
+    private final UserRepository userRepository;
+    private final ConversationStateRepository stateRepository;
+    private final ObjectMapper objectMapper = new ObjectMapper(new YAMLFactory());
+
+    private Map<String, FlowDefinition> flows = new HashMap<>();
+
+    @PostConstruct
+    void init() {
+        try {
+            FlowsConfig config = objectMapper.readValue(new ClassPathResource("flows.yml").getInputStream(), FlowsConfig.class);
+            if (config.getFlows() != null) {
+                config.getFlows().forEach(f -> flows.put(f.getId(), f));
+            }
+        } catch (IOException e) {
+            log.error("Failed to load flows configuration", e);
+        }
+    }
+
+    @Override
+    public List<String> listFlows() {
+        return new ArrayList<>(flows.keySet());
+    }
+
+    @Override
+    public FlowStepResponse nextStep(String flowId, FlowStepRequest request) {
+        FlowDefinition definition = flows.get(flowId);
+        if (definition == null) {
+            throw new IllegalArgumentException("Unknown flow: " + flowId);
+        }
+        User user = userRepository.findById(request.getUserId()).orElseThrow();
+        ConversationState state = stateRepository.findByUser_IdAndFlowId(user.getId(), flowId)
+                .orElseGet(() -> {
+                    ConversationState cs = new ConversationState();
+                    cs.setUser(user);
+                    cs.setFlowId(flowId);
+                    cs.setStep("start");
+                    return cs;
+                });
+
+        String currentStepId = state.getStep();
+        FlowStep current = definition.getSteps().stream()
+                .filter(s -> s.getId().equals(currentStepId))
+                .findFirst()
+                .orElseThrow();
+
+        String nextStepId = current.getTransitions() != null
+                ? current.getTransitions().getOrDefault(Optional.ofNullable(request.getIntent()).orElse(""), null)
+                : null;
+        if (nextStepId == null && current.getTransitions() != null) {
+            nextStepId = current.getTransitions().get("next");
+        }
+        if (nextStepId == null) {
+            nextStepId = currentStepId; // repeat same step if no transition
+        }
+
+        state.setStep(nextStepId);
+        if (request.getParams() != null) {
+            try {
+                state.setData(objectMapper.writeValueAsString(request.getParams()));
+            } catch (Exception e) {
+                log.warn("Failed to serialize params", e);
+            }
+        }
+        stateRepository.save(state);
+
+        FlowStep next = definition.getSteps().stream()
+                .filter(s -> s.getId().equals(nextStepId))
+                .findFirst()
+                .orElseThrow();
+
+        FlowStepResponse resp = new FlowStepResponse();
+        resp.setStep(nextStepId);
+        resp.setMessage(next.getMessage());
+        return resp;
+    }
+}

--- a/backend/bot/src/main/resources/flows.yml
+++ b/backend/bot/src/main/resources/flows.yml
@@ -1,0 +1,17 @@
+flows:
+  - id: "faq"
+    steps:
+      - id: "start"
+        message: "Benvenuto! Come posso aiutarti?"
+        transitions:
+          GENERIC: "answer"
+      - id: "answer"
+        message: "Questa è una risposta predefinita."
+  - id: "booking"
+    steps:
+      - id: "start"
+        message: "Quando vuoi prenotare?"
+        transitions:
+          GENERIC: "confirm"
+      - id: "confirm"
+        message: "Prenotazione registrata."


### PR DESCRIPTION
## Summary
- add conversational flow service with endpoints
- add conversation state entity and repository
- load flow definitions from YAML
- provide sample flows configuration
- enable YAML parser dependency

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68568364fed8832a9876a6a80c82ab50