### PR TITLE
Implement conversation flow handler and tests

### DIFF
--- a/backend/bot/src/main/java/com/whatsbot/controller/advice/RestExceptionHandler.java
+++ b/backend/bot/src/main/java/com/whatsbot/controller/advice/RestExceptionHandler.java
@@ -1,0 +1,23 @@
+package com.whatsbot.controller.advice;
+
+import com.whatsbot.dto.ErrorResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+import java.util.NoSuchElementException;
+
+@ControllerAdvice
+public class RestExceptionHandler {
+
+    @ExceptionHandler(NoSuchElementException.class)
+    public ResponseEntity<ErrorResponse> handleNotFound(NoSuchElementException ex) {
+        return new ResponseEntity<>(new ErrorResponse(ex.getMessage()), HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(IllegalStateException.class)
+    public ResponseEntity<ErrorResponse> handleBadRequest(IllegalStateException ex) {
+        return new ResponseEntity<>(new ErrorResponse(ex.getMessage()), HttpStatus.BAD_REQUEST);
+    }
+}

--- a/backend/bot/src/main/java/com/whatsbot/dto/ErrorResponse.java
+++ b/backend/bot/src/main/java/com/whatsbot/dto/ErrorResponse.java
@@ -1,0 +1,10 @@
+package com.whatsbot.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class ErrorResponse {
+    private String message;
+}

--- a/backend/bot/src/main/java/com/whatsbot/dto/FlowStepResponse.java
+++ b/backend/bot/src/main/java/com/whatsbot/dto/FlowStepResponse.java
@@ -6,4 +6,5 @@ import lombok.Data;
 public class FlowStepResponse {
     private String step;
     private String message;
+    private java.util.UUID stateId;
 }

--- a/backend/bot/src/main/java/com/whatsbot/service/impl/ConversationServiceImpl.java
+++ b/backend/bot/src/main/java/com/whatsbot/service/impl/ConversationServiceImpl.java
@@ -40,6 +40,7 @@ public class ConversationServiceImpl implements ConversationService {
         FlowStepResponse resp = new FlowStepResponse();
         resp.setStep("DATE");
         resp.setMessage("Per quale data desideri prenotare?");
+        resp.setStateId(state.getId());
         return resp;
     }
 
@@ -60,14 +61,14 @@ public class ConversationServiceImpl implements ConversationService {
                 state.setStep("TIME");
                 state.setData(writeData(data));
                 stateRepository.save(state);
-                return response("TIME", "A che ora?");
+                return response(state, "TIME", "A che ora?");
             }
             case "TIME" -> {
                 data.put("time", userResponse);
                 state.setStep("CONFIRM");
                 state.setData(writeData(data));
                 stateRepository.save(state);
-                return response("CONFIRM", "Confermi prenotazione per " + data.get("date") + " alle " + data.get("time") + "? (S\u00ec/No)");
+                return response(state, "CONFIRM", "Confermi prenotazione per " + data.get("date") + " alle " + data.get("time") + "? (Sì/No)");
             }
             case "CONFIRM" -> {
                 if (userResponse.equalsIgnoreCase("s\u00ec") || userResponse.equalsIgnoreCase("si")) {
@@ -76,10 +77,10 @@ public class ConversationServiceImpl implements ConversationService {
                     bookingService.createBooking(state.getUser().getId(), date, time);
                     state.setStep("DONE");
                     stateRepository.save(state);
-                    return response("DONE", "Prenotazione confermata");
+                    return response(state, "DONE", "Prenotazione confermata");
                 } else {
                     stateRepository.delete(state);
-                    return response("CANCELLED", "Prenotazione annullata");
+                    return response(state, "CANCELLED", "Prenotazione annullata");
                 }
             }
             default -> throw new IllegalStateException("Invalid step");
@@ -94,10 +95,11 @@ public class ConversationServiceImpl implements ConversationService {
         }
     }
 
-    private FlowStepResponse response(String step, String message) {
+    private FlowStepResponse response(ConversationState state, String step, String message) {
         FlowStepResponse resp = new FlowStepResponse();
         resp.setStep(step);
         resp.setMessage(message);
+        resp.setStateId(state.getId());
         return resp;
     }
 }

--- a/backend/bot/src/main/java/com/whatsbot/service/impl/ConversationalFlowServiceImpl.java
+++ b/backend/bot/src/main/java/com/whatsbot/service/impl/ConversationalFlowServiceImpl.java
@@ -100,6 +100,7 @@ public class ConversationalFlowServiceImpl implements ConversationalFlowService 
         FlowStepResponse resp = new FlowStepResponse();
         resp.setStep(nextStepId);
         resp.setMessage(next.getMessage());
+        resp.setStateId(state.getId());
         return resp;
     }
 }

--- a/backend/bot/src/test/java/com/whatsbot/controller/ConversationControllerTest.java
+++ b/backend/bot/src/test/java/com/whatsbot/controller/ConversationControllerTest.java
@@ -2,7 +2,10 @@ package com.whatsbot.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.whatsbot.model.User;
+import com.whatsbot.model.Booking;
 import com.whatsbot.repository.UserRepository;
+import com.whatsbot.repository.BookingRepository;
+import com.whatsbot.repository.ConversationStateRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,6 +16,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.UUID;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -24,6 +28,10 @@ class ConversationControllerTest {
     private MockMvc mockMvc;
     @Autowired
     private UserRepository userRepository;
+    @Autowired
+    private BookingRepository bookingRepository;
+    @Autowired
+    private ConversationStateRepository conversationStateRepository;
     @Autowired
     private ObjectMapper objectMapper;
 
@@ -48,4 +56,60 @@ class ConversationControllerTest {
     }
 
     private record Start(UUID userId) {}
+
+    @Test
+    void completeFlow() throws Exception {
+        String payload = objectMapper.writeValueAsString(new Start(userId));
+        String response = mockMvc.perform(post("/conversation/start")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(payload))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        UUID stateId = objectMapper.readValue(response, Step.class).stateId();
+
+        mockMvc.perform(post("/conversation/" + stateId + "/next")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new Next("2024-01-01"))))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(post("/conversation/" + stateId + "/next")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new Next("10:00"))))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(post("/conversation/" + stateId + "/next")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new Next("Sì"))))
+                .andExpect(status().isOk());
+
+        Booking booking = bookingRepository.findAll().get(0);
+        assertThat(booking.getUser().getId()).isEqualTo(userId);
+    }
+
+    @Test
+    void unknownStateReturns404() throws Exception {
+        UUID random = UUID.randomUUID();
+        mockMvc.perform(post("/conversation/" + random + "/next")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new Next("test"))))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void invalidStepReturns400() throws Exception {
+        var user = userRepository.findById(userId).orElseThrow();
+        var state = new com.whatsbot.model.ConversationState();
+        state.setUser(user);
+        state.setFlowId("booking");
+        state.setStep("UNKNOWN");
+        state = conversationStateRepository.save(state);
+
+        mockMvc.perform(post("/conversation/" + state.getId() + "/next")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new Next("test"))))
+                .andExpect(status().isBadRequest());
+    }
+
+    private record Step(UUID stateId, String step, String message){}
+    private record Next(String userResponse){}
 }


### PR DESCRIPTION
## Summary
- return stateId in booking flow responses
- add REST error handling
- expose stateId in generic flow service
- expand conversation flow integration tests

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857c7a325fc832a8f2b1ddd48c1cd4a