### PR TITLE
Add onboarding service with DTO validation and tests

### DIFF
--- a/backend/bot/src/main/java/com/whatsbot/controller/OnboardingController.java
+++ b/backend/bot/src/main/java/com/whatsbot/controller/OnboardingController.java
@@ -1,10 +1,16 @@
 package com.whatsbot.controller;
 
+import com.whatsbot.dto.OnboardStartRequest;
 import com.whatsbot.dto.OnboardStartResponse;
+import com.whatsbot.dto.OnboardVerifyRequest;
 import com.whatsbot.dto.OnboardVerifyResponse;
+import com.whatsbot.service.OnboardingService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -16,13 +22,20 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class OnboardingController {
 
+    private final OnboardingService onboardingService;
+
     @PostMapping("/start")
-    public ResponseEntity<OnboardStartResponse> start() {
-        return ResponseEntity.ok(new OnboardStartResponse());
+    public ResponseEntity<OnboardStartResponse> start(@Valid @RequestBody OnboardStartRequest request) {
+        OnboardStartResponse response = onboardingService.start(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
     @PostMapping("/verify")
-    public ResponseEntity<OnboardVerifyResponse> verify() {
-        return ResponseEntity.ok(new OnboardVerifyResponse());
+    public ResponseEntity<OnboardVerifyResponse> verify(@Valid @RequestBody OnboardVerifyRequest request) {
+        OnboardVerifyResponse response = onboardingService.verify(request);
+        if (response.isVerified()) {
+            return ResponseEntity.ok(response);
+        }
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
     }
 }

--- a/backend/bot/src/main/java/com/whatsbot/dto/OnboardStartRequest.java
+++ b/backend/bot/src/main/java/com/whatsbot/dto/OnboardStartRequest.java
@@ -1,0 +1,19 @@
+package com.whatsbot.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+/**
+ * Request payload for starting tenant onboarding.
+ */
+@Data
+public class OnboardStartRequest {
+    @NotBlank
+    private String baseUrl;
+    @NotBlank
+    private String phoneNumberId;
+    @NotBlank
+    private String accessToken;
+    @NotBlank
+    private String appSecret;
+}

--- a/backend/bot/src/main/java/com/whatsbot/dto/OnboardStartResponse.java
+++ b/backend/bot/src/main/java/com/whatsbot/dto/OnboardStartResponse.java
@@ -3,8 +3,9 @@ package com.whatsbot.dto;
 import lombok.Data;
 
 /**
- * Response for onboarding start. Currently empty by design.
+ * Response returned after starting the onboarding flow.
  */
 @Data
 public class OnboardStartResponse {
+    private String tenantId;
 }

--- a/backend/bot/src/main/java/com/whatsbot/dto/OnboardVerifyRequest.java
+++ b/backend/bot/src/main/java/com/whatsbot/dto/OnboardVerifyRequest.java
@@ -1,0 +1,13 @@
+package com.whatsbot.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+/**
+ * Request payload for verifying tenant onboarding.
+ */
+@Data
+public class OnboardVerifyRequest {
+    @NotBlank
+    private String tenantId;
+}

--- a/backend/bot/src/main/java/com/whatsbot/dto/OnboardVerifyResponse.java
+++ b/backend/bot/src/main/java/com/whatsbot/dto/OnboardVerifyResponse.java
@@ -3,8 +3,9 @@ package com.whatsbot.dto;
 import lombok.Data;
 
 /**
- * Response for onboarding verification. Currently empty by design.
+ * Response returned after verifying tenant onboarding.
  */
 @Data
 public class OnboardVerifyResponse {
+    private boolean verified;
 }

--- a/backend/bot/src/main/java/com/whatsbot/service/OnboardingService.java
+++ b/backend/bot/src/main/java/com/whatsbot/service/OnboardingService.java
@@ -1,0 +1,11 @@
+package com.whatsbot.service;
+
+import com.whatsbot.dto.OnboardStartRequest;
+import com.whatsbot.dto.OnboardStartResponse;
+import com.whatsbot.dto.OnboardVerifyRequest;
+import com.whatsbot.dto.OnboardVerifyResponse;
+
+public interface OnboardingService {
+    OnboardStartResponse start(OnboardStartRequest request);
+    OnboardVerifyResponse verify(OnboardVerifyRequest request);
+}

--- a/backend/bot/src/main/java/com/whatsbot/service/impl/OnboardingServiceImpl.java
+++ b/backend/bot/src/main/java/com/whatsbot/service/impl/OnboardingServiceImpl.java
@@ -1,0 +1,43 @@
+package com.whatsbot.service.impl;
+
+import com.whatsbot.dto.OnboardStartRequest;
+import com.whatsbot.dto.OnboardStartResponse;
+import com.whatsbot.dto.OnboardVerifyRequest;
+import com.whatsbot.dto.OnboardVerifyResponse;
+import com.whatsbot.model.TenantConfig;
+import com.whatsbot.repository.TenantConfigRepository;
+import com.whatsbot.service.OnboardingService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class OnboardingServiceImpl implements OnboardingService {
+
+    private final TenantConfigRepository tenantConfigRepository;
+
+    @Override
+    public OnboardStartResponse start(OnboardStartRequest request) {
+        TenantConfig config = new TenantConfig();
+        config.setTenantId(UUID.randomUUID().toString());
+        config.setBaseUrl(request.getBaseUrl());
+        config.setPhoneNumberId(request.getPhoneNumberId());
+        config.setAccessToken(request.getAccessToken());
+        config.setAppSecret(request.getAppSecret());
+        TenantConfig saved = tenantConfigRepository.save(config);
+
+        OnboardStartResponse response = new OnboardStartResponse();
+        response.setTenantId(saved.getTenantId());
+        return response;
+    }
+
+    @Override
+    public OnboardVerifyResponse verify(OnboardVerifyRequest request) {
+        boolean exists = tenantConfigRepository.findByTenantId(request.getTenantId()).isPresent();
+        OnboardVerifyResponse response = new OnboardVerifyResponse();
+        response.setVerified(exists);
+        return response;
+    }
+}

--- a/backend/bot/src/test/java/com/whatsbot/service/OnboardingServiceTest.java
+++ b/backend/bot/src/test/java/com/whatsbot/service/OnboardingServiceTest.java
@@ -1,0 +1,79 @@
+package com.whatsbot.service;
+
+import com.whatsbot.dto.OnboardStartRequest;
+import com.whatsbot.dto.OnboardVerifyRequest;
+import com.whatsbot.model.TenantConfig;
+import com.whatsbot.repository.TenantConfigRepository;
+import com.whatsbot.service.impl.OnboardingServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(MockitoExtension.class)
+class OnboardingServiceTest {
+
+    @Mock
+    private TenantConfigRepository tenantConfigRepository;
+
+    @InjectMocks
+    private OnboardingServiceImpl onboardingService;
+
+    private OnboardStartRequest startRequest;
+
+    @BeforeEach
+    void setup() {
+        startRequest = new OnboardStartRequest();
+        startRequest.setBaseUrl("http://test");
+        startRequest.setPhoneNumberId("123");
+        startRequest.setAccessToken("token");
+        startRequest.setAppSecret("secret");
+    }
+
+    @Test
+    void startCreatesTenant() {
+        when(tenantConfigRepository.save(any(TenantConfig.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        var response = onboardingService.start(startRequest);
+
+        ArgumentCaptor<TenantConfig> captor = ArgumentCaptor.forClass(TenantConfig.class);
+        verify(tenantConfigRepository).save(captor.capture());
+        assertThat(captor.getValue().getTenantId()).isNotBlank();
+        assertThat(response.getTenantId()).isEqualTo(captor.getValue().getTenantId());
+    }
+
+    @Test
+    void verifyExistingTenant() {
+        when(tenantConfigRepository.findByTenantId("abc"))
+                .thenReturn(Optional.of(new TenantConfig()));
+        OnboardVerifyRequest request = new OnboardVerifyRequest();
+        request.setTenantId("abc");
+
+        var response = onboardingService.verify(request);
+
+        assertThat(response.isVerified()).isTrue();
+    }
+
+    @Test
+    void verifyNonExistingTenant() {
+        when(tenantConfigRepository.findByTenantId("missing"))
+                .thenReturn(Optional.empty());
+        OnboardVerifyRequest request = new OnboardVerifyRequest();
+        request.setTenantId("missing");
+
+        var response = onboardingService.verify(request);
+
+        assertThat(response.isVerified()).isFalse();
+    }
+}


### PR DESCRIPTION
## Summary
- create DTOs for onboarding start/verify with field validation
- implement `OnboardingService` for tenant creation and verification
- connect `OnboardingController` to the new service
- return new `tenantId` and verification status in responses
- add unit tests for `OnboardingService`

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68591c59b818832aa6ebe895298d3156