### PR TITLE
Add onboarding wizard UI

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,13 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>WhatsBot Dashboard</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-VkzKmq0irW9Wcv16O3Qe9n1VWeNseyX2VINeodIZ6Tn6PvxI6Bfq5lHppZrgYhS/" crossorigin="anonymous" />
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css"
+      rel="stylesheet"
+      integrity="sha384-VkzKmq0irW9Wcv16O3Qe9n1VWeNseyX2VINeodIZ6Tn6PvxI6Bfq5lHppZrgYhS/"
+      crossorigin="anonymous"
+    />
+    <script src="https://cdn.tailwindcss.com"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,28 +1,6 @@
-import { useState } from 'react';
-import UserList from './components/UserList';
-import MessageHistory from './components/MessageHistory';
-import TemplateSender from './components/TemplateSender';
-import { User } from './types';
+import React from 'react';
+import Landing from './pages/Landing';
 
 export default function App() {
-  const [selectedUser, setSelectedUser] = useState<User | null>(null);
-
-  return (
-    <div className="container mt-4">
-      <div className="row">
-        <div className="col-md-4">
-          <UserList onSelect={setSelectedUser} />
-        </div>
-        <div className="col-md-8">
-          {selectedUser && (
-            <>
-              <h5>{selectedUser.name || selectedUser.phone}</h5>
-              <MessageHistory userId={selectedUser.id} />
-              <TemplateSender userId={selectedUser.id} />
-            </>
-          )}
-        </div>
-      </div>
-    </div>
-  );
+  return <Landing />;
 }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,10 +1,18 @@
 import axios from 'axios';
 
 const api = axios.create({
-  baseURL: '/api',
+  baseURL: '/',
   headers: {
     'Content-Type': 'application/json',
   },
 });
+
+export function onboardStart(body: unknown) {
+  return api.post<{ tenantId: string; token: string }>('/onboard/start', body);
+}
+
+export function onboardVerify(body: unknown) {
+  return api.post('/onboard/verify', body);
+}
 
 export default api;

--- a/frontend/src/components/Wizard.tsx
+++ b/frontend/src/components/Wizard.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import useWizard from '../hooks/useWizard';
+
+interface Props {
+  open: boolean;
+  onClose(): void;
+}
+
+export default function Wizard({ open, onClose }: Props) {
+  const { step, data, setData, next, prev, submitStart, submitVerify } = useWizard();
+
+  if (!open) return null;
+
+  const handleNext = async () => {
+    if (step === 1 && data.company) {
+      next();
+    } else if (step === 2 && data.phone) {
+      await submitStart();
+      next();
+    } else if (step === 3) {
+      next();
+    } else if (step === 4 && data.accepted) {
+      await submitVerify();
+      onClose();
+    }
+  };
+
+  const disabled =
+    (step === 1 && !data.company) || (step === 2 && !data.phone) || (step === 4 && !data.accepted);
+
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50">
+      <div className="bg-white rounded-lg p-6 w-full max-w-md">
+        <div className="mb-4 text-sm text-gray-500">Passo {step} di 4</div>
+        {step === 1 && (
+          <div className="space-y-4">
+            <label className="block text-sm font-medium">
+              Azienda
+              <input
+                className="mt-1 w-full border rounded-md p-2"
+                value={data.company}
+                onChange={(e) => setData({ ...data, company: e.target.value })}
+                required
+              />
+            </label>
+          </div>
+        )}
+        {step === 2 && (
+          <div className="space-y-4">
+            <label className="block text-sm font-medium">
+              Numero WhatsApp
+              <input
+                className="mt-1 w-full border rounded-md p-2"
+                value={data.phone}
+                onChange={(e) => setData({ ...data, phone: e.target.value })}
+                required
+              />
+            </label>
+          </div>
+        )}
+        {step === 3 && (
+          <div className="space-y-4">
+            <label className="block text-sm font-medium">
+              Codice SMS (opzionale)
+              <input
+                className="mt-1 w-full border rounded-md p-2"
+                value={data.code || ''}
+                onChange={(e) => setData({ ...data, code: e.target.value })}
+              />
+            </label>
+          </div>
+        )}
+        {step === 4 && (
+          <div className="space-y-4 text-sm">
+            <p>Azienda: {data.company}</p>
+            <p>Numero WhatsApp: {data.phone}</p>
+            <label className="flex items-center space-x-2">
+              <input
+                type="checkbox"
+                className="h-4 w-4"
+                checked={!!data.accepted}
+                onChange={(e) => setData({ ...data, accepted: e.target.checked })}
+              />
+              <span>Accetto i termini</span>
+            </label>
+          </div>
+        )}
+        <div className="mt-6 flex justify-between">
+          {step > 1 && (
+            <button className="px-4 py-2 text-sm rounded-md border" onClick={prev}>
+              Indietro
+            </button>
+          )}
+          <button
+            className="px-4 py-2 text-sm rounded-md bg-blue-600 text-white ml-auto"
+            onClick={handleNext}
+            disabled={disabled}
+          >
+            {step === 4 ? 'Invia' : 'Avanti'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useWizard.ts
+++ b/frontend/src/hooks/useWizard.ts
@@ -1,0 +1,33 @@
+import { useState } from 'react';
+import { onboardStart, onboardVerify } from '../api';
+
+export interface WizardData {
+  company: string;
+  phone: string;
+  code?: string;
+  tenantId?: string;
+  token?: string;
+  accepted?: boolean;
+}
+
+export default function useWizard() {
+  const [step, setStep] = useState(1);
+  const [data, setData] = useState<WizardData>({
+    company: '',
+    phone: '',
+  });
+
+  const next = () => setStep((s) => (s < 4 ? s + 1 : s));
+  const prev = () => setStep((s) => (s > 1 ? s - 1 : s));
+
+  const submitStart = async () => {
+    const res = await onboardStart({ company: data.company, phone: data.phone });
+    setData((d) => ({ ...d, tenantId: res.data.tenantId, token: res.data.token }));
+  };
+
+  const submitVerify = async () => {
+    await onboardVerify({ tenantId: data.tenantId, token: data.token, code: data.code });
+  };
+
+  return { step, data, setData, next, prev, submitStart, submitVerify };
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -6,5 +6,5 @@ import 'bootstrap/dist/css/bootstrap.min.css';
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>
+  </React.StrictMode>,
 );

--- a/frontend/src/pages/Landing.tsx
+++ b/frontend/src/pages/Landing.tsx
@@ -1,0 +1,21 @@
+import React, { useState } from 'react';
+import Wizard from '../components/Wizard';
+
+export default function Landing() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen bg-gray-100 p-4">
+      <h1 className="text-3xl font-bold mb-4 text-center">
+        Automatizza WhatsApp per la tua azienda
+      </h1>
+      <p className="text-lg mb-6 text-center">
+        Configura in pochi passi il tuo bot personalizzato.
+      </p>
+      <button className="px-6 py-3 rounded-md bg-blue-600 text-white" onClick={() => setOpen(true)}>
+        Inizia ora
+      </button>
+      <Wizard open={open} onClose={() => setOpen(false)} />
+    </div>
+  );
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   server: {
     port: 3000,
     proxy: {
-      '/api': {
+      '/onboard': {
         target: 'http://localhost:8080',
         changeOrigin: true,
       },


### PR DESCRIPTION
## Summary
- add Tailwind CDN to index.html
- create landing page with hero section
- implement 4-step onboarding wizard and state hook
- update axios helper and Vite proxy
- replace App with Landing page

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*
- `npm run format`
- `mvn spotless:apply` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859326a9200832ab1afc7ff59b07b2e