### PR TITLE
Add onboarding wizard

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -1,0 +1,32 @@
+import js from '@eslint/js';
+import react from 'eslint-plugin-react';
+import tseslint from '@typescript-eslint/eslint-plugin';
+import parser from '@typescript-eslint/parser';
+import prettier from 'eslint-config-prettier';
+
+export default [
+  {
+    files: ['**/*.{ts,tsx}'],
+    languageOptions: {
+      parser,
+      parserOptions: {
+        ecmaVersion: 'latest',
+        sourceType: 'module',
+        ecmaFeatures: { jsx: true },
+      },
+    },
+    plugins: {
+      react,
+      '@typescript-eslint': tseslint,
+    },
+    settings: { react: { version: 'detect' } },
+    rules: {},
+  },
+  {
+    ...js.configs.recommended,
+    rules: {
+      ...js.configs.recommended.rules,
+      ...prettier.rules,
+    },
+  },
+];

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,13 +9,15 @@
     "preview": "vite preview",
     "lint": "eslint \"src/**/*.{ts,tsx}\"",
     "format": "prettier --write \"src/**/*.{ts,tsx,js,jsx,json,css}\"",
-    "prepare": "husky install ../.husky"
+    "prepare": "husky install ../.husky",
+    "test": "vitest"
   },
   "dependencies": {
     "axios": "^1.6.2",
     "bootstrap": "^5.3.2",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.23.0"
   },
   "devDependencies": {
     "@types/react": "^18.0.24",
@@ -29,7 +31,11 @@
     "@typescript-eslint/parser": "^6.13.0",
     "@typescript-eslint/eslint-plugin": "^6.13.0",
     "eslint-plugin-react": "^7.33.2",
-    "husky": "^9.0.11"
+    "husky": "^9.0.11",
+    "vitest": "^1.4.0",
+    "@testing-library/react": "^14.2.0",
+    "@testing-library/user-event": "^14.4.3",
+    "@testing-library/jest-dom": "^6.1.5"
 
   }
 }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,4 +1,10 @@
 import axios from 'axios';
+import {
+  OnboardStartRequest,
+  OnboardStartResponse,
+  OnboardVerifyRequest,
+  OnboardVerifyResponse,
+} from './types';
 
 const api = axios.create({
   baseURL: '/',
@@ -7,12 +13,14 @@ const api = axios.create({
   },
 });
 
-export function onboardStart(body: unknown) {
-  return api.post<{ tenantId: string; token: string }>('/onboard/start', body);
+export async function onboardStart(body: OnboardStartRequest): Promise<OnboardStartResponse> {
+  const { data } = await api.post<OnboardStartResponse>('/onboard/start', body);
+  return data;
 }
 
-export function onboardVerify(body: unknown) {
-  return api.post('/onboard/verify', body);
+export async function onboardVerify(body: OnboardVerifyRequest): Promise<OnboardVerifyResponse> {
+  const { data } = await api.post<OnboardVerifyResponse>('/onboard/verify', body);
+  return data;
 }
 
 export default api;

--- a/frontend/src/components/OnboardingWizard.test.tsx
+++ b/frontend/src/components/OnboardingWizard.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+import OnboardingWizard from './OnboardingWizard';
+
+vi.mock('../api', () => ({
+  onboardStart: vi.fn().mockResolvedValue({ tenantId: '1', token: 't' }),
+  onboardVerify: vi.fn().mockResolvedValue({ verified: true }),
+}));
+
+test('advances to second step on Avanti click', async () => {
+  render(<OnboardingWizard />);
+  await userEvent.type(screen.getByLabelText(/Nome azienda/i), 'Acme');
+  await userEvent.type(screen.getByLabelText(/Numero di telefono/i), '123');
+  await userEvent.click(screen.getByRole('button', { name: /Avanti/i }));
+  expect(screen.getByLabelText(/Codice SMS/i)).toBeInTheDocument();
+});

--- a/frontend/src/components/OnboardingWizard.tsx
+++ b/frontend/src/components/OnboardingWizard.tsx
@@ -1,0 +1,87 @@
+import React, { FormEvent, useState } from 'react';
+import useOnboarding from '../hooks/useOnboarding';
+import { OnboardStartRequest } from '../types';
+
+export default function OnboardingWizard() {
+  const { step, data, setData, next, prev, start, verify } = useOnboarding();
+  const [code, setCode] = useState('');
+  const [completed, setCompleted] = useState(false);
+
+  const handleStart = async (e: FormEvent) => {
+    e.preventDefault();
+    await start(data as OnboardStartRequest);
+    next();
+  };
+
+  const handleVerify = async (e: FormEvent) => {
+    e.preventDefault();
+    const res = await verify(code);
+    if (res.verified) {
+      setCompleted(true);
+    }
+  };
+
+  if (completed) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <div className="text-center">Setup completato</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-center justify-center min-h-screen">
+      <div className="bg-white p-6 rounded shadow-md w-full max-w-md">
+        <div className="mb-4 text-sm text-gray-500">Passo {step} di 2</div>
+        {step === 1 && (
+          <form onSubmit={handleStart} className="space-y-4">
+            <label className="block text-sm font-medium">
+              Nome azienda
+              <input
+                className="mt-1 w-full border rounded p-2"
+                value={data.businessName || ''}
+                onChange={(e) => setData({ ...data, businessName: e.target.value })}
+                required
+              />
+            </label>
+            <label className="block text-sm font-medium">
+              Numero di telefono
+              <input
+                className="mt-1 w-full border rounded p-2"
+                value={data.phoneNumber || ''}
+                onChange={(e) => setData({ ...data, phoneNumber: e.target.value })}
+                required
+              />
+            </label>
+            <div className="flex justify-end">
+              <button type="submit" className="px-4 py-2 bg-blue-600 text-white rounded">
+                Avanti
+              </button>
+            </div>
+          </form>
+        )}
+        {step === 2 && (
+          <form onSubmit={handleVerify} className="space-y-4">
+            <label className="block text-sm font-medium">
+              Codice SMS
+              <input
+                className="mt-1 w-full border rounded p-2"
+                value={code}
+                onChange={(e) => setCode(e.target.value)}
+                required
+              />
+            </label>
+            <div className="flex justify-between">
+              <button type="button" onClick={prev} className="px-4 py-2 border rounded">
+                Indietro
+              </button>
+              <button type="submit" className="px-4 py-2 bg-blue-600 text-white rounded">
+                Avanti
+              </button>
+            </div>
+          </form>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useOnboarding.ts
+++ b/frontend/src/hooks/useOnboarding.ts
@@ -1,0 +1,26 @@
+import { useState } from 'react';
+import { onboardStart, onboardVerify } from '../api';
+import { OnboardStartRequest, OnboardStartResponse, OnboardVerifyResponse } from '../types';
+
+export default function useOnboarding() {
+  const [step, setStep] = useState(1);
+  const [data, setData] = useState<Partial<OnboardStartRequest>>({});
+  const [tenantId, setTenantId] = useState('');
+  const [token, setToken] = useState('');
+
+  const next = () => setStep((s) => Math.min(s + 1, 2));
+  const prev = () => setStep((s) => Math.max(s - 1, 1));
+
+  const start = async (values: OnboardStartRequest): Promise<OnboardStartResponse> => {
+    const res = await onboardStart(values);
+    setTenantId(res.tenantId);
+    setToken(res.token);
+    return res;
+  };
+
+  const verify = async (code: string): Promise<OnboardVerifyResponse> => {
+    return onboardVerify({ tenantId, token, code });
+  };
+
+  return { step, data, setData, tenantId, token, next, prev, start, verify };
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,10 +1,17 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import App from './App';
+import { createBrowserRouter, RouterProvider } from 'react-router-dom';
+import Landing from './pages/Landing';
+import OnboardPage from './pages/OnboardPage';
 import 'bootstrap/dist/css/bootstrap.min.css';
+
+const router = createBrowserRouter([
+  { path: '/', element: <Landing /> },
+  { path: '/onboard', element: <OnboardPage /> },
+]);
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
-    <App />
+    <RouterProvider router={router} />
   </React.StrictMode>,
 );

--- a/frontend/src/pages/OnboardPage.tsx
+++ b/frontend/src/pages/OnboardPage.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import OnboardingWizard from '../components/OnboardingWizard';
+
+export default function OnboardPage() {
+  return <OnboardingWizard />;
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -16,3 +16,23 @@ export interface Message {
 export interface Template {
   name: string;
 }
+
+export interface OnboardStartRequest {
+  businessName: string;
+  phoneNumber: string;
+}
+
+export interface OnboardStartResponse {
+  tenantId: string;
+  token: string;
+}
+
+export interface OnboardVerifyRequest {
+  tenantId: string;
+  token: string;
+  code: string;
+}
+
+export interface OnboardVerifyResponse {
+  verified: boolean;
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -12,4 +12,7 @@ export default defineConfig({
       },
     },
   },
+  test: {
+    environment: 'jsdom',
+  },
 });


### PR DESCRIPTION
## Summary
- add onboarding hook with API integration
- create onboarding wizard component and page
- wire up routing for `/onboard`
- define onboarding DTOs and API methods
- configure vitest and eslint, add basic test

## Testing
- `npm --prefix frontend run lint` *(fails: Cannot find package '/workspace/WhatsappBot/frontend/node_modules/@eslint/js/index.js' imported from /workspace/WhatsappBot/frontend/eslint.config.js)*
- `npm --prefix frontend run format`
- `npm --prefix frontend run test` *(fails: vitest: not found)*


------
https://chatgpt.com/codex/tasks/task_e_6859372bc2a8832a8ed0790f131d29e1