### PR TITLE
Implement broadcast module

### DIFF
--- a/backend/bot/pom.xml
+++ b/backend/bot/pom.xml
@@ -23,6 +23,7 @@
         <postgresql.version>42.7.3</postgresql.version>
         <lombok.version>1.18.30</lombok.version>
         <jjwt.version>0.12.6</jjwt.version>
+        <mapstruct.version>1.5.5.Final</mapstruct.version>
     </properties>
 
     <dependencies>
@@ -58,6 +59,17 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct</artifactId>
+            <version>${mapstruct.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct-processor</artifactId>
+            <version>${mapstruct.version}</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -67,6 +79,21 @@
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <configuration>
                     <mainClass>com.whatsbot.WhatsAppBotApplication</mainClass>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.mapstruct</groupId>
+                            <artifactId>mapstruct-processor</artifactId>
+                            <version>${mapstruct.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
                 </configuration>
             </plugin>
             <plugin>

--- a/backend/bot/src/main/java/com/whatsbot/broadcast/controller/BroadcastController.java
+++ b/backend/bot/src/main/java/com/whatsbot/broadcast/controller/BroadcastController.java
@@ -1,0 +1,30 @@
+package com.whatsbot.broadcast.controller;
+
+import com.whatsbot.broadcast.dto.BroadcastCreateRequest;
+import com.whatsbot.broadcast.dto.BroadcastMessageDto;
+import com.whatsbot.broadcast.service.BroadcastService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/broadcasts")
+@RequiredArgsConstructor
+public class BroadcastController {
+
+    private final BroadcastService broadcastService;
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public BroadcastMessageDto create(@Valid @RequestBody BroadcastCreateRequest request) {
+        return broadcastService.create(request);
+    }
+
+    @GetMapping
+    public List<BroadcastMessageDto> list() {
+        return broadcastService.findAll();
+    }
+}

--- a/backend/bot/src/main/java/com/whatsbot/broadcast/dto/BroadcastCreateRequest.java
+++ b/backend/bot/src/main/java/com/whatsbot/broadcast/dto/BroadcastCreateRequest.java
@@ -1,0 +1,16 @@
+package com.whatsbot.broadcast.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+import java.time.Instant;
+
+@Data
+public class BroadcastCreateRequest {
+    @NotBlank
+    private String text;
+
+    @NotNull
+    private Instant scheduledAt;
+}

--- a/backend/bot/src/main/java/com/whatsbot/broadcast/dto/BroadcastMessageDto.java
+++ b/backend/bot/src/main/java/com/whatsbot/broadcast/dto/BroadcastMessageDto.java
@@ -1,0 +1,15 @@
+package com.whatsbot.broadcast.dto;
+
+import com.whatsbot.broadcast.model.BroadcastStatus;
+import lombok.Data;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Data
+public class BroadcastMessageDto {
+    private UUID id;
+    private String text;
+    private Instant scheduledAt;
+    private BroadcastStatus status;
+}

--- a/backend/bot/src/main/java/com/whatsbot/broadcast/mapper/BroadcastMapper.java
+++ b/backend/bot/src/main/java/com/whatsbot/broadcast/mapper/BroadcastMapper.java
@@ -1,0 +1,18 @@
+package com.whatsbot.broadcast.mapper;
+
+import com.whatsbot.broadcast.dto.BroadcastCreateRequest;
+import com.whatsbot.broadcast.dto.BroadcastMessageDto;
+import com.whatsbot.broadcast.model.BroadcastMessage;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface BroadcastMapper {
+    BroadcastMessageDto toDto(BroadcastMessage entity);
+
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "tenantId", ignore = true)
+    @Mapping(target = "status", expression = "java(com.whatsbot.broadcast.model.BroadcastStatus.PENDING)")
+    @Mapping(target = "createdAt", ignore = true)
+    BroadcastMessage toEntity(BroadcastCreateRequest request);
+}

--- a/backend/bot/src/main/java/com/whatsbot/broadcast/model/BroadcastMessage.java
+++ b/backend/bot/src/main/java/com/whatsbot/broadcast/model/BroadcastMessage.java
@@ -1,0 +1,38 @@
+package com.whatsbot.broadcast.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "broadcast_messages")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class BroadcastMessage {
+
+    @Id
+    @GeneratedValue
+    private UUID id;
+
+    private UUID tenantId;
+
+    @Column(nullable = false)
+    private String text;
+
+    private Instant scheduledAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private BroadcastStatus status;
+
+    @CreationTimestamp
+    private Instant createdAt;
+}

--- a/backend/bot/src/main/java/com/whatsbot/broadcast/model/BroadcastStatus.java
+++ b/backend/bot/src/main/java/com/whatsbot/broadcast/model/BroadcastStatus.java
@@ -1,0 +1,7 @@
+package com.whatsbot.broadcast.model;
+
+public enum BroadcastStatus {
+    PENDING,
+    SENT,
+    FAILED
+}

--- a/backend/bot/src/main/java/com/whatsbot/broadcast/repository/BroadcastMessageRepository.java
+++ b/backend/bot/src/main/java/com/whatsbot/broadcast/repository/BroadcastMessageRepository.java
@@ -1,0 +1,9 @@
+package com.whatsbot.broadcast.repository;
+
+import com.whatsbot.broadcast.model.BroadcastMessage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface BroadcastMessageRepository extends JpaRepository<BroadcastMessage, UUID> {
+}

--- a/backend/bot/src/main/java/com/whatsbot/broadcast/service/BroadcastService.java
+++ b/backend/bot/src/main/java/com/whatsbot/broadcast/service/BroadcastService.java
@@ -1,0 +1,12 @@
+package com.whatsbot.broadcast.service;
+
+import com.whatsbot.broadcast.dto.BroadcastCreateRequest;
+import com.whatsbot.broadcast.dto.BroadcastMessageDto;
+
+import java.util.List;
+
+public interface BroadcastService {
+    BroadcastMessageDto create(BroadcastCreateRequest request);
+
+    List<BroadcastMessageDto> findAll();
+}

--- a/backend/bot/src/main/java/com/whatsbot/broadcast/service/impl/BroadcastServiceImpl.java
+++ b/backend/bot/src/main/java/com/whatsbot/broadcast/service/impl/BroadcastServiceImpl.java
@@ -1,0 +1,37 @@
+package com.whatsbot.broadcast.service.impl;
+
+import com.whatsbot.broadcast.dto.BroadcastCreateRequest;
+import com.whatsbot.broadcast.dto.BroadcastMessageDto;
+import com.whatsbot.broadcast.mapper.BroadcastMapper;
+import com.whatsbot.broadcast.model.BroadcastMessage;
+import com.whatsbot.broadcast.repository.BroadcastMessageRepository;
+import com.whatsbot.broadcast.service.BroadcastService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class BroadcastServiceImpl implements BroadcastService {
+
+    private final BroadcastMessageRepository repository;
+    private final BroadcastMapper mapper;
+
+    @Override
+    public BroadcastMessageDto create(BroadcastCreateRequest request) {
+        BroadcastMessage entity = mapper.toEntity(request);
+        entity.setTenantId(UUID.randomUUID());
+        BroadcastMessage saved = repository.save(entity);
+        return mapper.toDto(saved);
+    }
+
+    @Override
+    public List<BroadcastMessageDto> findAll() {
+        return repository.findAll().stream()
+                .map(mapper::toDto)
+                .collect(Collectors.toList());
+    }
+}

--- a/backend/bot/src/test/java/com/whatsbot/broadcast/service/BroadcastServiceImplTest.java
+++ b/backend/bot/src/test/java/com/whatsbot/broadcast/service/BroadcastServiceImplTest.java
@@ -1,0 +1,48 @@
+package com.whatsbot.broadcast.service;
+
+import com.whatsbot.broadcast.dto.BroadcastCreateRequest;
+import com.whatsbot.broadcast.dto.BroadcastMessageDto;
+import com.whatsbot.broadcast.mapper.BroadcastMapper;
+import com.whatsbot.broadcast.model.BroadcastMessage;
+import com.whatsbot.broadcast.repository.BroadcastMessageRepository;
+import com.whatsbot.broadcast.service.impl.BroadcastServiceImpl;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class BroadcastServiceImplTest {
+
+    @Mock
+    private BroadcastMessageRepository repository;
+    @Mock
+    private BroadcastMapper mapper;
+    @InjectMocks
+    private BroadcastServiceImpl service;
+
+    @Test
+    void createSavesBroadcast() {
+        BroadcastCreateRequest req = new BroadcastCreateRequest();
+        req.setText("hello");
+        req.setScheduledAt(Instant.now());
+        BroadcastMessage entity = new BroadcastMessage();
+        BroadcastMessage saved = new BroadcastMessage();
+        BroadcastMessageDto dto = new BroadcastMessageDto();
+
+        when(mapper.toEntity(req)).thenReturn(entity);
+        when(repository.save(entity)).thenReturn(saved);
+        when(mapper.toDto(saved)).thenReturn(dto);
+
+        BroadcastMessageDto result = service.create(req);
+
+        assertThat(result).isEqualTo(dto);
+        verify(repository).save(entity);
+    }
+}

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -4,6 +4,8 @@ import {
   OnboardStartResponse,
   OnboardVerifyRequest,
   OnboardVerifyResponse,
+  BroadcastMessage,
+  BroadcastCreateRequest,
 } from './types';
 
 const api = axios.create({
@@ -20,6 +22,16 @@ export async function onboardStart(body: OnboardStartRequest): Promise<OnboardSt
 
 export async function onboardVerify(body: OnboardVerifyRequest): Promise<OnboardVerifyResponse> {
   const { data } = await api.post<OnboardVerifyResponse>('/onboard/verify', body);
+  return data;
+}
+
+export async function getBroadcasts() {
+  const { data } = await api.get<BroadcastMessage[]>('/api/broadcasts');
+  return data;
+}
+
+export async function createBroadcast(body: BroadcastCreateRequest) {
+  const { data } = await api.post<BroadcastMessage>('/api/broadcasts', body);
   return data;
 }
 

--- a/frontend/src/components/BroadcastForm.tsx
+++ b/frontend/src/components/BroadcastForm.tsx
@@ -1,0 +1,51 @@
+import { useState } from 'react';
+import { createBroadcast } from '../api';
+import { BroadcastCreateRequest } from '../types';
+
+interface Props {
+  onCreated(): void;
+}
+
+export default function BroadcastForm({ onCreated }: Props) {
+  const [text, setText] = useState('');
+  const [date, setDate] = useState('');
+
+  const submit = async () => {
+    if (!text || !date) return;
+    const payload: BroadcastCreateRequest = {
+      text,
+      scheduledAt: new Date(date).toISOString(),
+    };
+    await createBroadcast(payload);
+    setText('');
+    setDate('');
+    onCreated();
+  };
+
+  return (
+    <div className="card mb-3">
+      <div className="card-body">
+        <h5 className="card-title">Nuovo broadcast</h5>
+        <div className="mb-2">
+          <textarea
+            className="form-control"
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            placeholder="Messaggio"
+          />
+        </div>
+        <div className="mb-2">
+          <input
+            type="datetime-local"
+            className="form-control"
+            value={date}
+            onChange={(e) => setDate(e.target.value)}
+          />
+        </div>
+        <button className="btn btn-primary" onClick={submit} disabled={!text || !date}>
+          Pianifica
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/BroadcastList.tsx
+++ b/frontend/src/components/BroadcastList.tsx
@@ -1,0 +1,31 @@
+import { useEffect, useState } from 'react';
+import { getBroadcasts } from '../api';
+import { BroadcastMessage } from '../types';
+
+export default function BroadcastList() {
+  const [items, setItems] = useState<BroadcastMessage[]>([]);
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const load = () => {
+    getBroadcasts().then(setItems);
+  };
+
+  return (
+    <div className="card">
+      <div className="card-body">
+        <h5 className="card-title">Broadcast programmati</h5>
+        <ul className="list-group">
+          {items.map((b) => (
+            <li key={b.id} className="list-group-item d-flex justify-content-between">
+              <span>{b.text}</span>
+              <small>{new Date(b.scheduledAt).toLocaleString()}</small>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/BroadcastForm.test.tsx
+++ b/frontend/src/components/__tests__/BroadcastForm.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+import BroadcastForm from '../BroadcastForm';
+import * as api from '../../api';
+
+vi.mock('../../api');
+
+const mocked = api as { createBroadcast: any };
+
+test('submit invokes API', async () => {
+  const create = vi.fn().mockResolvedValue({});
+  mocked.createBroadcast = create;
+  render(<BroadcastForm onCreated={() => {}} />);
+  await userEvent.type(screen.getByPlaceholderText(/Messaggio/i), 'hello');
+  await userEvent.type(screen.getByLabelText(/datetime-local/i), '2024-01-01T12:00');
+  await userEvent.click(screen.getByRole('button', { name: /Pianifica/i }));
+  expect(create).toHaveBeenCalled();
+});

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,11 +3,13 @@ import ReactDOM from 'react-dom/client';
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import Landing from './pages/Landing';
 import OnboardPage from './pages/OnboardPage';
+import BroadcastPage from './pages/BroadcastPage';
 import 'bootstrap/dist/css/bootstrap.min.css';
 
 const router = createBrowserRouter([
   { path: '/', element: <Landing /> },
   { path: '/onboard', element: <OnboardPage /> },
+  { path: '/broadcast', element: <BroadcastPage /> },
 ]);
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(

--- a/frontend/src/pages/BroadcastPage.tsx
+++ b/frontend/src/pages/BroadcastPage.tsx
@@ -1,0 +1,12 @@
+import BroadcastForm from '../components/BroadcastForm';
+import BroadcastList from '../components/BroadcastList';
+
+export default function BroadcastPage() {
+  return (
+    <div className="container py-4">
+      <h2 className="mb-3">Gestione Broadcast</h2>
+      <BroadcastForm onCreated={() => {}} />
+      <BroadcastList />
+    </div>
+  );
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -36,3 +36,15 @@ export interface OnboardVerifyRequest {
 export interface OnboardVerifyResponse {
   verified: boolean;
 }
+
+export interface BroadcastMessage {
+  id: string;
+  text: string;
+  scheduledAt: string;
+  status: string;
+}
+
+export interface BroadcastCreateRequest {
+  text: string;
+  scheduledAt: string;
+}


### PR DESCRIPTION
## Summary
- add broadcast module with controller, DTOs, mapper and service
- integrate MapStruct into build
- expose broadcasts API
- create React UI for broadcasts
- add unit tests

## Testing
- `mvn -q -f backend/bot/pom.xml spotless:apply` *(fails: `mvn: command not found`)*
- `npm --prefix frontend run lint` *(fails: missing packages due to offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_685a75ab33e4832aab90b46092a7a886