### PR TITLE
Add auth module with Spring Security

### DIFF
--- a/backend/bot/pom.xml
+++ b/backend/bot/pom.xml
@@ -39,6 +39,38 @@
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-api</artifactId>
+            <version>${jjwt.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-impl</artifactId>
+            <version>${jjwt.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-jackson</artifactId>
+            <version>${jjwt.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct</artifactId>
+            <version>1.5.5.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct-processor</artifactId>
+            <version>1.5.5.Final</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <version>${postgresql.version}</version>
@@ -58,10 +90,33 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.mapstruct</groupId>
+                            <artifactId>mapstruct-processor</artifactId>
+                            <version>1.5.5.Final</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>

--- a/backend/bot/src/main/java/com/whatsbot/auth/config/SecurityConfig.java
+++ b/backend/bot/src/main/java/com/whatsbot/auth/config/SecurityConfig.java
@@ -1,0 +1,47 @@
+package com.whatsbot.auth.config;
+
+import com.whatsbot.auth.middleware.TenantFilter;
+import com.whatsbot.auth.security.AuthUserDetailsService;
+import com.whatsbot.auth.security.JwtAuthFilter;
+import com.whatsbot.auth.security.JwtService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final AuthUserDetailsService userDetailsService;
+    private final JwtService jwtService;
+
+    @Bean
+    SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http.csrf().disable()
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/auth/**").permitAll()
+                        .anyRequest().authenticated())
+                .sessionManagement(man -> man.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .addFilterBefore(new JwtAuthFilter(jwtService, userDetailsService), UsernamePasswordAuthenticationFilter.class)
+                .addFilterAfter(new TenantFilter(jwtService), JwtAuthFilter.class);
+        return http.build();
+    }
+
+    @Bean
+    PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+        return configuration.getAuthenticationManager();
+    }
+}

--- a/backend/bot/src/main/java/com/whatsbot/auth/controller/AuthController.java
+++ b/backend/bot/src/main/java/com/whatsbot/auth/controller/AuthController.java
@@ -1,0 +1,20 @@
+package com.whatsbot.auth.controller;
+
+import com.whatsbot.auth.dto.LoginRequest;
+import com.whatsbot.auth.dto.LoginResponse;
+import com.whatsbot.auth.service.AuthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/login")
+    public LoginResponse login(@RequestBody LoginRequest request) {
+        return authService.login(request);
+    }
+}

--- a/backend/bot/src/main/java/com/whatsbot/auth/dto/LoginRequest.java
+++ b/backend/bot/src/main/java/com/whatsbot/auth/dto/LoginRequest.java
@@ -1,0 +1,4 @@
+package com.whatsbot.auth.dto;
+
+public record LoginRequest(String username, String password, String tenant) {
+}

--- a/backend/bot/src/main/java/com/whatsbot/auth/dto/LoginResponse.java
+++ b/backend/bot/src/main/java/com/whatsbot/auth/dto/LoginResponse.java
@@ -1,0 +1,4 @@
+package com.whatsbot.auth.dto;
+
+public record LoginResponse(String token) {
+}

--- a/backend/bot/src/main/java/com/whatsbot/auth/dto/UserDto.java
+++ b/backend/bot/src/main/java/com/whatsbot/auth/dto/UserDto.java
@@ -1,0 +1,7 @@
+package com.whatsbot.auth.dto;
+
+import java.util.List;
+import java.util.UUID;
+
+public record UserDto(UUID id, String username, UUID tenantId, List<String> roles) {
+}

--- a/backend/bot/src/main/java/com/whatsbot/auth/exception/AuthException.java
+++ b/backend/bot/src/main/java/com/whatsbot/auth/exception/AuthException.java
@@ -1,0 +1,7 @@
+package com.whatsbot.auth.exception;
+
+public class AuthException extends RuntimeException {
+    public AuthException(String message) {
+        super(message);
+    }
+}

--- a/backend/bot/src/main/java/com/whatsbot/auth/exception/AuthExceptionHandler.java
+++ b/backend/bot/src/main/java/com/whatsbot/auth/exception/AuthExceptionHandler.java
@@ -1,0 +1,16 @@
+package com.whatsbot.auth.exception;
+
+import com.whatsbot.common.response.ErrorResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class AuthExceptionHandler {
+
+    @ExceptionHandler(AuthException.class)
+    public ResponseEntity<ErrorResponse> handleAuth(AuthException ex) {
+        return new ResponseEntity<>(new ErrorResponse(ex.getMessage()), HttpStatus.UNAUTHORIZED);
+    }
+}

--- a/backend/bot/src/main/java/com/whatsbot/auth/mapper/AuthUserMapper.java
+++ b/backend/bot/src/main/java/com/whatsbot/auth/mapper/AuthUserMapper.java
@@ -1,0 +1,16 @@
+package com.whatsbot.auth.mapper;
+
+import com.whatsbot.auth.dto.UserDto;
+import com.whatsbot.auth.model.AuthUser;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+@Mapper(componentModel = "spring")
+public interface AuthUserMapper {
+    AuthUserMapper INSTANCE = Mappers.getMapper(AuthUserMapper.class);
+
+    @Mapping(target = "tenantId", source = "tenant.id")
+    @Mapping(target = "roles", expression = "java(user.getRoles().stream().map(r -> r.getName()).toList())")
+    UserDto toDto(AuthUser user);
+}

--- a/backend/bot/src/main/java/com/whatsbot/auth/middleware/TenantContext.java
+++ b/backend/bot/src/main/java/com/whatsbot/auth/middleware/TenantContext.java
@@ -1,0 +1,19 @@
+package com.whatsbot.auth.middleware;
+
+import java.util.UUID;
+
+public class TenantContext {
+    private static final ThreadLocal<UUID> CURRENT = new ThreadLocal<>();
+
+    public static void set(UUID tenantId) {
+        CURRENT.set(tenantId);
+    }
+
+    public static UUID get() {
+        return CURRENT.get();
+    }
+
+    public static void clear() {
+        CURRENT.remove();
+    }
+}

--- a/backend/bot/src/main/java/com/whatsbot/auth/middleware/TenantFilter.java
+++ b/backend/bot/src/main/java/com/whatsbot/auth/middleware/TenantFilter.java
@@ -1,0 +1,39 @@
+package com.whatsbot.auth.middleware;
+
+import com.whatsbot.auth.security.JwtService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.UUID;
+
+public class TenantFilter extends OncePerRequestFilter {
+
+    private final JwtService jwtService;
+
+    public TenantFilter(JwtService jwtService) {
+        this.jwtService = jwtService;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        String auth = request.getHeader("Authorization");
+        if (auth != null && auth.startsWith("Bearer ")) {
+            String token = auth.substring(7);
+            UUID tenantId = jwtService.extractTenant(token);
+            if (tenantId != null) {
+                TenantContext.set(tenantId);
+            }
+        }
+        try {
+            filterChain.doFilter(request, response);
+        } finally {
+            TenantContext.clear();
+        }
+    }
+}

--- a/backend/bot/src/main/java/com/whatsbot/auth/model/AccessLevel.java
+++ b/backend/bot/src/main/java/com/whatsbot/auth/model/AccessLevel.java
@@ -1,0 +1,21 @@
+package com.whatsbot.auth.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "access_levels")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AccessLevel {
+    @Id
+    @GeneratedValue
+    private UUID id;
+
+    @Column(nullable = false, unique = true)
+    private String name;
+}

--- a/backend/bot/src/main/java/com/whatsbot/auth/model/AuthUser.java
+++ b/backend/bot/src/main/java/com/whatsbot/auth/model/AuthUser.java
@@ -1,0 +1,35 @@
+package com.whatsbot.auth.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+@Entity
+@Table(name = "auth_users")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AuthUser {
+    @Id
+    @GeneratedValue
+    private UUID id;
+
+    @Column(nullable = false, unique = true)
+    private String username;
+
+    @Column(nullable = false)
+    private String password;
+
+    @ManyToOne(optional = false)
+    private Tenant tenant;
+
+    @ManyToMany(fetch = FetchType.EAGER)
+    @JoinTable(name = "user_roles",
+        joinColumns = @JoinColumn(name = "user_id"),
+        inverseJoinColumns = @JoinColumn(name = "role_id"))
+    private Set<Role> roles = new HashSet<>();
+}

--- a/backend/bot/src/main/java/com/whatsbot/auth/model/Role.java
+++ b/backend/bot/src/main/java/com/whatsbot/auth/model/Role.java
@@ -1,0 +1,29 @@
+package com.whatsbot.auth.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+@Entity
+@Table(name = "roles")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Role {
+    @Id
+    @GeneratedValue
+    private UUID id;
+
+    @Column(nullable = false, unique = true)
+    private String name;
+
+    @ManyToMany(fetch = FetchType.EAGER)
+    @JoinTable(name = "role_access_levels",
+        joinColumns = @JoinColumn(name = "role_id"),
+        inverseJoinColumns = @JoinColumn(name = "access_level_id"))
+    private Set<AccessLevel> accessLevels = new HashSet<>();
+}

--- a/backend/bot/src/main/java/com/whatsbot/auth/model/Tenant.java
+++ b/backend/bot/src/main/java/com/whatsbot/auth/model/Tenant.java
@@ -1,0 +1,21 @@
+package com.whatsbot.auth.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "tenants")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Tenant {
+    @Id
+    @GeneratedValue
+    private UUID id;
+
+    @Column(nullable = false, unique = true)
+    private String name;
+}

--- a/backend/bot/src/main/java/com/whatsbot/auth/repository/AccessLevelRepository.java
+++ b/backend/bot/src/main/java/com/whatsbot/auth/repository/AccessLevelRepository.java
@@ -1,0 +1,11 @@
+package com.whatsbot.auth.repository;
+
+import com.whatsbot.auth.model.AccessLevel;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface AccessLevelRepository extends JpaRepository<AccessLevel, UUID> {
+}

--- a/backend/bot/src/main/java/com/whatsbot/auth/repository/AuthUserRepository.java
+++ b/backend/bot/src/main/java/com/whatsbot/auth/repository/AuthUserRepository.java
@@ -1,0 +1,13 @@
+package com.whatsbot.auth.repository;
+
+import com.whatsbot.auth.model.AuthUser;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface AuthUserRepository extends JpaRepository<AuthUser, UUID> {
+    Optional<AuthUser> findByUsernameAndTenant_Name(String username, String tenantName);
+}

--- a/backend/bot/src/main/java/com/whatsbot/auth/repository/RoleRepository.java
+++ b/backend/bot/src/main/java/com/whatsbot/auth/repository/RoleRepository.java
@@ -1,0 +1,11 @@
+package com.whatsbot.auth.repository;
+
+import com.whatsbot.auth.model.Role;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface RoleRepository extends JpaRepository<Role, UUID> {
+}

--- a/backend/bot/src/main/java/com/whatsbot/auth/repository/TenantRepository.java
+++ b/backend/bot/src/main/java/com/whatsbot/auth/repository/TenantRepository.java
@@ -1,0 +1,13 @@
+package com.whatsbot.auth.repository;
+
+import com.whatsbot.auth.model.Tenant;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface TenantRepository extends JpaRepository<Tenant, UUID> {
+    Optional<Tenant> findByName(String name);
+}

--- a/backend/bot/src/main/java/com/whatsbot/auth/security/AuthUserDetailsService.java
+++ b/backend/bot/src/main/java/com/whatsbot/auth/security/AuthUserDetailsService.java
@@ -1,0 +1,39 @@
+package com.whatsbot.auth.security;
+
+import com.whatsbot.auth.exception.AuthException;
+import com.whatsbot.auth.model.AuthUser;
+import com.whatsbot.auth.repository.AuthUserRepository;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class AuthUserDetailsService implements UserDetailsService {
+
+    private final AuthUserRepository repository;
+
+    public AuthUserDetailsService(AuthUserRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        throw new UsernameNotFoundException("Tenant required");
+    }
+
+    public UserDetails loadByUsernameAndTenant(String username, String tenant) {
+        AuthUser user = repository.findByUsernameAndTenant_Name(username, tenant)
+                .orElseThrow(() -> new AuthException("Invalid credentials"));
+        List<GrantedAuthority> auths = user.getRoles().stream()
+                .map(r -> new SimpleGrantedAuthority(r.getName()))
+                .collect(Collectors.toList());
+        return new org.springframework.security.core.userdetails.User(
+                user.getUsername(), user.getPassword(), auths);
+    }
+}

--- a/backend/bot/src/main/java/com/whatsbot/auth/security/JwtAuthFilter.java
+++ b/backend/bot/src/main/java/com/whatsbot/auth/security/JwtAuthFilter.java
@@ -1,0 +1,43 @@
+package com.whatsbot.auth.security;
+
+import com.whatsbot.auth.middleware.TenantContext;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+public class JwtAuthFilter extends OncePerRequestFilter {
+
+    private final JwtService jwtService;
+    private final AuthUserDetailsService userDetailsService;
+
+    public JwtAuthFilter(JwtService jwtService, AuthUserDetailsService userDetailsService) {
+        this.jwtService = jwtService;
+        this.userDetailsService = userDetailsService;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        String auth = request.getHeader("Authorization");
+        if (auth != null && auth.startsWith("Bearer ")) {
+            String token = auth.substring(7);
+            var username = jwtService.extractUsername(token);
+            var tenantId = jwtService.extractTenant(token);
+            if (username != null && tenantId != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+                TenantContext.set(tenantId);
+                var details = userDetailsService.loadByUsernameAndTenant(username, tenantId.toString());
+                var authToken = new UsernamePasswordAuthenticationToken(details, null, details.getAuthorities());
+                authToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                SecurityContextHolder.getContext().setAuthentication(authToken);
+            }
+        }
+        filterChain.doFilter(request, response);
+    }
+}

--- a/backend/bot/src/main/java/com/whatsbot/auth/security/JwtService.java
+++ b/backend/bot/src/main/java/com/whatsbot/auth/security/JwtService.java
@@ -1,0 +1,50 @@
+package com.whatsbot.auth.security;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.security.Key;
+import java.util.Date;
+import java.util.UUID;
+
+@Service
+public class JwtService {
+
+    private final Key key;
+
+    public JwtService(@Value("${app.jwt.secret:secret}") String secret) {
+        this.key = Keys.hmacShaKeyFor(secret.getBytes());
+    }
+
+    public String generateToken(UUID userId, String username, UUID tenantId) {
+        long now = System.currentTimeMillis();
+        return Jwts.builder()
+                .claim("uid", userId.toString())
+                .claim("sub", username)
+                .claim("tid", tenantId.toString())
+                .setIssuedAt(new Date(now))
+                .setExpiration(new Date(now + 3600_000))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public UUID extractUser(String token) {
+        String id = Jwts.parserBuilder().setSigningKey(key).build()
+                .parseClaimsJws(token).getBody().get("uid", String.class);
+        return id != null ? UUID.fromString(id) : null;
+    }
+
+    public UUID extractTenant(String token) {
+        String id = Jwts.parserBuilder().setSigningKey(key).build()
+                .parseClaimsJws(token).getBody().get("tid", String.class);
+        return id != null ? UUID.fromString(id) : null;
+    }
+
+    public String extractUsername(String token) {
+        return Jwts.parserBuilder().setSigningKey(key).build()
+                .parseClaimsJws(token).getBody().get("sub", String.class);
+    }
+}

--- a/backend/bot/src/main/java/com/whatsbot/auth/service/AuthService.java
+++ b/backend/bot/src/main/java/com/whatsbot/auth/service/AuthService.java
@@ -1,0 +1,37 @@
+package com.whatsbot.auth.service;
+
+import com.whatsbot.auth.dto.LoginRequest;
+import com.whatsbot.auth.dto.LoginResponse;
+import com.whatsbot.auth.dto.UserDto;
+import com.whatsbot.auth.exception.AuthException;
+import com.whatsbot.auth.mapper.AuthUserMapper;
+import com.whatsbot.auth.model.AuthUser;
+import com.whatsbot.auth.repository.AuthUserRepository;
+import com.whatsbot.auth.security.JwtService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final AuthUserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtService jwtService;
+    private final AuthUserMapper mapper;
+
+    public LoginResponse login(LoginRequest request) {
+        AuthUser user = userRepository.findByUsernameAndTenant_Name(request.username(), request.tenant())
+                .orElseThrow(() -> new AuthException("Invalid credentials"));
+        if (!passwordEncoder.matches(request.password(), user.getPassword())) {
+            throw new AuthException("Invalid credentials");
+        }
+        String token = jwtService.generateToken(user.getId(), user.getUsername(), user.getTenant().getId());
+        return new LoginResponse(token);
+    }
+
+    public UserDto toDto(AuthUser user) {
+        return mapper.toDto(user);
+    }
+}

--- a/backend/bot/src/test/java/com/whatsbot/auth/AuthControllerTest.java
+++ b/backend/bot/src/test/java/com/whatsbot/auth/AuthControllerTest.java
@@ -1,0 +1,62 @@
+package com.whatsbot.auth;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.whatsbot.auth.model.AuthUser;
+import com.whatsbot.auth.model.Tenant;
+import com.whatsbot.auth.repository.AuthUserRepository;
+import com.whatsbot.auth.repository.TenantRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class AuthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private TenantRepository tenantRepository;
+    @Autowired
+    private AuthUserRepository userRepository;
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private Tenant tenant;
+
+    @BeforeEach
+    void setup() {
+        userRepository.deleteAll();
+        tenantRepository.deleteAll();
+        tenant = tenantRepository.save(new Tenant(null, "acme"));
+        AuthUser u = new AuthUser();
+        u.setUsername("john");
+        u.setPassword(passwordEncoder.encode("pwd"));
+        u.setTenant(tenant);
+        userRepository.save(u);
+    }
+
+    @Test
+    void loginSuccess() throws Exception {
+        var req = new Login("john", "pwd", "acme");
+        mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.token").isNotEmpty());
+    }
+
+    private record Login(String username, String password, String tenant) {}
+}

--- a/backend/bot/src/test/java/com/whatsbot/auth/JwtServiceTest.java
+++ b/backend/bot/src/test/java/com/whatsbot/auth/JwtServiceTest.java
@@ -1,0 +1,27 @@
+package com.whatsbot.auth;
+
+import com.whatsbot.auth.security.JwtService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.UUID;
+
+@SpringBootTest
+class JwtServiceTest {
+
+    @Autowired
+    JwtService jwtService;
+
+    @Test
+    void roundTrip() {
+        UUID uid = UUID.randomUUID();
+        UUID tid = UUID.randomUUID();
+        String token = jwtService.generateToken(uid, "user", tid);
+        assertThat(jwtService.extractUser(token)).isEqualTo(uid);
+        assertThat(jwtService.extractTenant(token)).isEqualTo(tid);
+        assertThat(jwtService.extractUsername(token)).isEqualTo("user");
+    }
+}

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -4,6 +4,8 @@ import {
   OnboardStartResponse,
   OnboardVerifyRequest,
   OnboardVerifyResponse,
+  LoginRequest,
+  LoginResponse,
 } from './types';
 
 const api = axios.create({
@@ -13,6 +15,15 @@ const api = axios.create({
   },
 });
 
+api.interceptors.request.use((config) => {
+  const token = localStorage.getItem('token');
+  if (token) {
+    config.headers = config.headers || {};
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
+
 export async function onboardStart(body: OnboardStartRequest): Promise<OnboardStartResponse> {
   const { data } = await api.post<OnboardStartResponse>('/onboard/start', body);
   return data;
@@ -20,6 +31,11 @@ export async function onboardStart(body: OnboardStartRequest): Promise<OnboardSt
 
 export async function onboardVerify(body: OnboardVerifyRequest): Promise<OnboardVerifyResponse> {
   const { data } = await api.post<OnboardVerifyResponse>('/onboard/verify', body);
+  return data;
+}
+
+export async function login(body: LoginRequest): Promise<LoginResponse> {
+  const { data } = await api.post<LoginResponse>('/api/auth/login', body);
   return data;
 }
 

--- a/frontend/src/components/auth/RequireAuth.tsx
+++ b/frontend/src/components/auth/RequireAuth.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { Navigate } from 'react-router-dom';
+import useAuth from '../../hooks/useAuth';
+
+export default function RequireAuth({ children }: { children: JSX.Element }) {
+  const { token } = useAuth();
+  if (!token) {
+    return <Navigate to="/login" replace />;
+  }
+  return children;
+}

--- a/frontend/src/hooks/useAuth.test.tsx
+++ b/frontend/src/hooks/useAuth.test.tsx
@@ -1,0 +1,13 @@
+import { renderHook, act } from '@testing-library/react';
+import useAuth, { AuthProvider } from './useAuth';
+
+test('login stores token', () => {
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <AuthProvider>{children}</AuthProvider>
+  );
+  const { result } = renderHook(() => useAuth(), { wrapper });
+  act(() => {
+    result.current.login('t');
+  });
+  expect(result.current.token).toBe('t');
+});

--- a/frontend/src/hooks/useAuth.tsx
+++ b/frontend/src/hooks/useAuth.tsx
@@ -1,0 +1,33 @@
+import React, { createContext, useContext, useState } from 'react';
+
+interface AuthContextValue {
+  token: string;
+  login(token: string): void;
+  logout(): void;
+}
+
+const AuthContext = createContext<AuthContextValue>(null!);
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [token, setToken] = useState(() => localStorage.getItem('token') || '');
+
+  const login = (t: string) => {
+    setToken(t);
+    localStorage.setItem('token', t);
+  };
+
+  const logout = () => {
+    setToken('');
+    localStorage.removeItem('token');
+  };
+
+  return (
+    <AuthContext.Provider value={{ token, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export default function useAuth() {
+  return useContext(AuthContext);
+}

--- a/frontend/src/hooks/useLogin.ts
+++ b/frontend/src/hooks/useLogin.ts
@@ -1,0 +1,20 @@
+import { useState } from 'react';
+import { login as loginApi } from '../api';
+import { LoginRequest } from '../types';
+import useAuth from './useAuth';
+
+export default function useLogin() {
+  const auth = useAuth();
+  const [error, setError] = useState('');
+
+  const login = async (req: LoginRequest) => {
+    try {
+      const res = await loginApi(req);
+      auth.login(res.token);
+    } catch {
+      setError('Credenziali non valide');
+    }
+  };
+
+  return { login, error };
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,15 +3,27 @@ import ReactDOM from 'react-dom/client';
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import Landing from './pages/Landing';
 import OnboardPage from './pages/OnboardPage';
+import LoginPage from './pages/LoginPage';
+import DashboardPage from './pages/DashboardPage';
+import RequireAuth from './components/auth/RequireAuth';
+import { AuthProvider } from './hooks/useAuth';
 import 'bootstrap/dist/css/bootstrap.min.css';
 
 const router = createBrowserRouter([
   { path: '/', element: <Landing /> },
   { path: '/onboard', element: <OnboardPage /> },
+  { path: '/login', element: <LoginPage /> },
+  { path: '/dashboard', element: (
+      <RequireAuth>
+        <DashboardPage />
+      </RequireAuth>
+    ) },
 ]);
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
-    <RouterProvider router={router} />
+    <AuthProvider>
+      <RouterProvider router={router} />
+    </AuthProvider>
   </React.StrictMode>,
 );

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function DashboardPage() {
+  return <div className="p-4">Benvenuto nella dashboard</div>;
+}

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,0 +1,50 @@
+import React, { FormEvent, useState } from 'react';
+import useLogin from '../hooks/useLogin';
+import { useNavigate } from 'react-router-dom';
+
+export default function LoginPage() {
+  const { login, error } = useLogin();
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [tenant, setTenant] = useState('');
+  const navigate = useNavigate();
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    await login({ username, password, tenant });
+    navigate('/dashboard');
+  };
+
+  return (
+    <div className="flex items-center justify-center min-h-screen">
+      <form onSubmit={handleSubmit} className="space-y-4 w-full max-w-sm">
+        <input
+          className="w-full border p-2 rounded"
+          placeholder="Tenant"
+          value={tenant}
+          onChange={(e) => setTenant(e.target.value)}
+          required
+        />
+        <input
+          className="w-full border p-2 rounded"
+          placeholder="Username"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+          required
+        />
+        <input
+          className="w-full border p-2 rounded"
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+        />
+        {error && <div className="text-red-600 text-sm">{error}</div>}
+        <button className="w-full bg-blue-600 text-white p-2 rounded" type="submit">
+          Login
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -36,3 +36,13 @@ export interface OnboardVerifyRequest {
 export interface OnboardVerifyResponse {
   verified: boolean;
 }
+
+export interface LoginRequest {
+  username: string;
+  password: string;
+  tenant: string;
+}
+
+export interface LoginResponse {
+  token: string;
+}


### PR DESCRIPTION
## Summary
- add Spring Security, MapStruct and JWT to backend pom
- implement auth module with entities, repositories, service and controller
- include JWT-based security config and tenant isolation middleware
- provide JUnit tests for token service and login
- add React login page with token storage and protected routes
- implement useAuth and useLogin hooks with unit test

## Testing
- `mvn -q test` *(fails: command not found)*
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a7a777a0c832a90ede3a86b782fcf