### PR TITLE
Switch profiles to Postgres

### DIFF
--- a/backend/bot/pom.xml
+++ b/backend/bot/pom.xml
@@ -85,8 +85,13 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.h2database</groupId>
-            <artifactId>h2</artifactId>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/backend/bot/src/main/resources/application-dev.yml
+++ b/backend/bot/src/main/resources/application-dev.yml
@@ -7,21 +7,20 @@ logging:
   pattern:
     console: '{"time":"%d{ISO8601}","level":"%p","logger":"%c{1}","message":"%m"}%n'
   file:
-    name: whatsbot.log
-    path: logs
+    name: logs/whatsbot.log
 
 spring:
   datasource:
-    url: jdbc:h2:mem:whatsbot;DB_CLOSE_DELAY=-1
-    username: sa
-    password: 
-    driver-class-name: org.h2.Driver
+    url: jdbc:postgresql://localhost:5432/whatsapp_bot
+    username: admin
+    password: admin
+    driver-class-name: org.postgresql.Driver
   jpa:
-    open-in-view: false
     hibernate:
-      ddl-auto: create-drop
-    show-sql: false
-
+      ddl-auto: update
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
 
 whatsapp:
   base-url: ${WHATSAPP_BASE_URL:https://graph.facebook.com/v17.0}

--- a/backend/bot/src/main/resources/application-test.yml
+++ b/backend/bot/src/main/resources/application-test.yml
@@ -1,0 +1,42 @@
+server:
+  port: 8080
+
+logging:
+  level:
+    root: INFO
+  pattern:
+    console: '{"time":"%d{ISO8601}","level":"%p","logger":"%c{1}","message":"%m"}%n'
+  file:
+    name: logs/whatsbot.log
+
+spring:
+  datasource:
+    url: jdbc:postgresql://localhost:5432/whatsapp_bot_test
+    username: admin
+    password: admin
+    driver-class-name: org.postgresql.Driver
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+
+whatsapp:
+  base-url: ${WHATSAPP_BASE_URL:https://graph.facebook.com/v17.0}
+  phone-number-id: ${WHATSAPP_PHONE_NUMBER_ID}
+  access-token: ${WHATSAPP_ACCESS_TOKEN}
+  app-secret: ${WHATSAPP_APP_SECRET}
+
+webhook:
+  token-ngrok: ${NGROK_AUTHTOKEN}
+
+cors:
+  enabled: true
+  allowed-origins:
+    - "http://localhost:3000"
+
+info:
+  open-hours:
+    monday-friday: "9-18"
+    saturday: "10-14"

--- a/backend/bot/src/test/java/com/whatsbot/auth/AuthControllerTest.java
+++ b/backend/bot/src/test/java/com/whatsbot/auth/AuthControllerTest.java
@@ -7,6 +7,12 @@ import com.whatsbot.auth.repository.AuthUserRepository;
 import com.whatsbot.auth.repository.TenantRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -19,9 +25,24 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@Testcontainers
 @SpringBootTest
 @AutoConfigureMockMvc
+@ActiveProfiles("test")
 class AuthControllerTest {
+
+    @Container
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:15")
+            .withDatabaseName("whatsbot_test")
+            .withUsername("admin")
+            .withPassword("admin");
+
+    @DynamicPropertySource
+    static void registerPgProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+    }
 
     @Autowired
     private MockMvc mockMvc;

--- a/backend/bot/src/test/java/com/whatsbot/auth/JwtServiceTest.java
+++ b/backend/bot/src/test/java/com/whatsbot/auth/JwtServiceTest.java
@@ -4,12 +4,14 @@ import com.whatsbot.auth.security.JwtService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.UUID;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class JwtServiceTest {
 
     @Autowired

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
     build:
       context: ./backend
     environment:
-      SPRING_PROFILES_ACTIVE: docker
+      SPRING_PROFILES_ACTIVE: prod
       SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/whatsapp_bot
       SPRING_DATASOURCE_USERNAME: admin
       SPRING_DATASOURCE_PASSWORD: admin


### PR DESCRIPTION
## Summary
- remove h2 from backend
- add testcontainers for tests
- create dev/test profiles with Postgres
- use prod profile in docker-compose

## Testing
- `mvn -q test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685a86bd2f50832aa5db61eb58a54c96