### PR TITLE
Implement multi-tenant booking module

### DIFF
--- a/backend/bot/src/main/java/com/whatsbot/booking/management/controller/AdminController.java
+++ b/backend/bot/src/main/java/com/whatsbot/booking/management/controller/AdminController.java
@@ -1,0 +1,60 @@
+package com.whatsbot.booking.management.controller;
+
+import com.whatsbot.booking.management.dto.AvailabilityDto;
+import com.whatsbot.booking.management.dto.ServiceDto;
+import com.whatsbot.booking.management.service.AvailabilityService;
+import com.whatsbot.booking.management.service.ServiceOfferingService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/admin/booking")
+@RequiredArgsConstructor
+public class AdminController {
+
+    private final ServiceOfferingService serviceService;
+    private final AvailabilityService availabilityService;
+
+    @GetMapping("/services")
+    public List<ServiceDto> services() {
+        return serviceService.list();
+    }
+
+    @PostMapping("/services")
+    public ServiceDto createService(@RequestBody ServiceDto dto) {
+        return serviceService.create(dto);
+    }
+
+    @PutMapping("/services/{id}")
+    public ServiceDto updateService(@PathVariable UUID id, @RequestBody ServiceDto dto) {
+        return serviceService.update(id, dto);
+    }
+
+    @DeleteMapping("/services/{id}")
+    public void deleteService(@PathVariable UUID id) {
+        serviceService.delete(id);
+    }
+
+    @GetMapping("/availability")
+    public List<AvailabilityDto> availability() {
+        return availabilityService.list();
+    }
+
+    @PostMapping("/availability")
+    public AvailabilityDto createAvailability(@RequestBody AvailabilityDto dto) {
+        return availabilityService.create(dto);
+    }
+
+    @PutMapping("/availability/{id}")
+    public AvailabilityDto updateAvailability(@PathVariable UUID id, @RequestBody AvailabilityDto dto) {
+        return availabilityService.update(id, dto);
+    }
+
+    @DeleteMapping("/availability/{id}")
+    public void deleteAvailability(@PathVariable UUID id) {
+        availabilityService.delete(id);
+    }
+}

--- a/backend/bot/src/main/java/com/whatsbot/booking/management/controller/BookingManagementController.java
+++ b/backend/bot/src/main/java/com/whatsbot/booking/management/controller/BookingManagementController.java
@@ -1,0 +1,63 @@
+package com.whatsbot.booking.management.controller;
+
+import com.whatsbot.booking.management.dto.AppointmentDto;
+import com.whatsbot.booking.management.dto.SlotDto;
+import com.whatsbot.booking.management.service.BookingManager;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/booking")
+@RequiredArgsConstructor
+public class BookingManagementController {
+
+    private final BookingManager bookingManager;
+
+    @PostMapping("/create")
+    public ResponseEntity<AppointmentDto> create(@RequestBody @NotNull CreateRequest request) {
+        AppointmentDto dto = bookingManager.create(request.userId, request.serviceId, LocalDate.parse(request.date), request.time);
+        return new ResponseEntity<>(dto, HttpStatus.CREATED);
+    }
+
+    @GetMapping("/slots")
+    public List<SlotDto> slots(@RequestParam UUID serviceId, @RequestParam String date) {
+        return bookingManager.availableSlots(serviceId, LocalDate.parse(date));
+    }
+
+    @GetMapping("/pending")
+    public List<AppointmentDto> pending() {
+        return bookingManager.pending();
+    }
+
+    @PostMapping("/approve")
+    public void approve(@RequestBody ApproveRequest request) {
+        bookingManager.approve(request.bookingId);
+    }
+
+    @Data
+    private static class CreateRequest {
+        @NotNull
+        private UUID userId;
+        @NotNull
+        private UUID serviceId;
+        @NotBlank
+        private String date;
+        @NotBlank
+        private String time;
+    }
+
+    @Data
+    private static class ApproveRequest {
+        @NotNull
+        private UUID bookingId;
+    }
+}

--- a/backend/bot/src/main/java/com/whatsbot/booking/management/dto/AppointmentDto.java
+++ b/backend/bot/src/main/java/com/whatsbot/booking/management/dto/AppointmentDto.java
@@ -1,0 +1,12 @@
+package com.whatsbot.booking.management.dto;
+
+import java.util.UUID;
+
+public class AppointmentDto {
+    public UUID id;
+    public UUID userId;
+    public UUID serviceId;
+    public String date;
+    public String time;
+    public String status;
+}

--- a/backend/bot/src/main/java/com/whatsbot/booking/management/dto/AvailabilityDto.java
+++ b/backend/bot/src/main/java/com/whatsbot/booking/management/dto/AvailabilityDto.java
@@ -1,0 +1,10 @@
+package com.whatsbot.booking.management.dto;
+
+import java.util.UUID;
+
+public class AvailabilityDto {
+    public UUID id;
+    public String dayOfWeek;
+    public String startTime;
+    public String endTime;
+}

--- a/backend/bot/src/main/java/com/whatsbot/booking/management/dto/ServiceDto.java
+++ b/backend/bot/src/main/java/com/whatsbot/booking/management/dto/ServiceDto.java
@@ -1,0 +1,11 @@
+package com.whatsbot.booking.management.dto;
+
+import java.util.UUID;
+
+public class ServiceDto {
+    public UUID id;
+    public String name;
+    public int durationMinutes;
+    public int bufferMinutes;
+    public int maxPerSlot;
+}

--- a/backend/bot/src/main/java/com/whatsbot/booking/management/dto/SlotDto.java
+++ b/backend/bot/src/main/java/com/whatsbot/booking/management/dto/SlotDto.java
@@ -1,0 +1,6 @@
+package com.whatsbot.booking.management.dto;
+
+public class SlotDto {
+    public String time;
+    public int remaining;
+}

--- a/backend/bot/src/main/java/com/whatsbot/booking/management/init/BookingDataInitializer.java
+++ b/backend/bot/src/main/java/com/whatsbot/booking/management/init/BookingDataInitializer.java
@@ -1,0 +1,40 @@
+package com.whatsbot.booking.management.init;
+
+import com.whatsbot.auth.model.Tenant;
+import com.whatsbot.auth.repository.TenantRepository;
+import com.whatsbot.booking.management.model.Availability;
+import com.whatsbot.booking.management.model.ServiceOffering;
+import com.whatsbot.booking.management.repository.AvailabilityRepository;
+import com.whatsbot.booking.management.repository.ServiceOfferingRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+
+@Component
+@RequiredArgsConstructor
+public class BookingDataInitializer implements CommandLineRunner {
+
+    private final TenantRepository tenantRepository;
+    private final ServiceOfferingRepository serviceRepository;
+    private final AvailabilityRepository availabilityRepository;
+
+    @Override
+    public void run(String... args) {
+        if (serviceRepository.count() > 0) {
+            return;
+        }
+        Tenant tenant = tenantRepository.findByName("demo").orElseThrow();
+        ServiceOffering service = new ServiceOffering(null, tenant, "Consultation", 30, 10, 1);
+        service = serviceRepository.save(service);
+        for (DayOfWeek day : DayOfWeek.values()) {
+            if (day.getValue() <= 5) {
+                Availability a = new Availability(null, tenant, day,
+                        LocalTime.of(9, 0), LocalTime.of(17, 0));
+                availabilityRepository.save(a);
+            }
+        }
+    }
+}

--- a/backend/bot/src/main/java/com/whatsbot/booking/management/mapper/AppointmentMapper.java
+++ b/backend/bot/src/main/java/com/whatsbot/booking/management/mapper/AppointmentMapper.java
@@ -1,0 +1,23 @@
+package com.whatsbot.booking.management.mapper;
+
+import com.whatsbot.booking.management.dto.AppointmentDto;
+import com.whatsbot.booking.management.model.Appointment;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AppointmentMapper {
+
+    public AppointmentDto toDto(Appointment entity) {
+        if (entity == null) {
+            return null;
+        }
+        AppointmentDto dto = new AppointmentDto();
+        dto.id = entity.getId();
+        dto.userId = entity.getUser().getId();
+        dto.serviceId = entity.getService().getId();
+        dto.date = entity.getDate().toString();
+        dto.time = entity.getTime().toString();
+        dto.status = entity.getStatus().name();
+        return dto;
+    }
+}

--- a/backend/bot/src/main/java/com/whatsbot/booking/management/mapper/AvailabilityMapper.java
+++ b/backend/bot/src/main/java/com/whatsbot/booking/management/mapper/AvailabilityMapper.java
@@ -1,0 +1,48 @@
+package com.whatsbot.booking.management.mapper;
+
+import com.whatsbot.booking.management.dto.AvailabilityDto;
+import com.whatsbot.booking.management.model.Availability;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AvailabilityMapper {
+
+    public AvailabilityDto toDto(Availability entity) {
+        if (entity == null) {
+            return null;
+        }
+        AvailabilityDto dto = new AvailabilityDto();
+        dto.id = entity.getId();
+        dto.dayOfWeek = entity.getDayOfWeek().name();
+        dto.startTime = entity.getStartTime().toString();
+        dto.endTime = entity.getEndTime().toString();
+        return dto;
+    }
+
+    public Availability toEntity(AvailabilityDto dto) {
+        if (dto == null) {
+            return null;
+        }
+        Availability entity = new Availability();
+        entity.setId(dto.id);
+        entity.setDayOfWeek(java.time.DayOfWeek.valueOf(dto.dayOfWeek));
+        entity.setStartTime(java.time.LocalTime.parse(dto.startTime));
+        entity.setEndTime(java.time.LocalTime.parse(dto.endTime));
+        return entity;
+    }
+
+    public void update(AvailabilityDto dto, Availability entity) {
+        if (dto == null || entity == null) {
+            return;
+        }
+        if (dto.dayOfWeek != null) {
+            entity.setDayOfWeek(java.time.DayOfWeek.valueOf(dto.dayOfWeek));
+        }
+        if (dto.startTime != null) {
+            entity.setStartTime(java.time.LocalTime.parse(dto.startTime));
+        }
+        if (dto.endTime != null) {
+            entity.setEndTime(java.time.LocalTime.parse(dto.endTime));
+        }
+    }
+}

--- a/backend/bot/src/main/java/com/whatsbot/booking/management/mapper/ServiceMapper.java
+++ b/backend/bot/src/main/java/com/whatsbot/booking/management/mapper/ServiceMapper.java
@@ -1,0 +1,50 @@
+package com.whatsbot.booking.management.mapper;
+
+import com.whatsbot.booking.management.dto.ServiceDto;
+import com.whatsbot.booking.management.model.ServiceOffering;
+import org.springframework.stereotype.Component;
+
+/**
+ * Simple mapper without MapStruct to convert ServiceOffering entities.
+ */
+@Component
+public class ServiceMapper {
+
+    public ServiceDto toDto(ServiceOffering entity) {
+        if (entity == null) {
+            return null;
+        }
+        ServiceDto dto = new ServiceDto();
+        dto.id = entity.getId();
+        dto.name = entity.getName();
+        dto.durationMinutes = entity.getDurationMinutes();
+        dto.bufferMinutes = entity.getBufferMinutes();
+        dto.maxPerSlot = entity.getMaxPerSlot();
+        return dto;
+    }
+
+    public ServiceOffering toEntity(ServiceDto dto) {
+        if (dto == null) {
+            return null;
+        }
+        ServiceOffering entity = new ServiceOffering();
+        entity.setId(dto.id);
+        entity.setName(dto.name);
+        entity.setDurationMinutes(dto.durationMinutes);
+        entity.setBufferMinutes(dto.bufferMinutes);
+        entity.setMaxPerSlot(dto.maxPerSlot);
+        return entity;
+    }
+
+    public void update(ServiceDto dto, ServiceOffering entity) {
+        if (dto == null || entity == null) {
+            return;
+        }
+        if (dto.name != null) {
+            entity.setName(dto.name);
+        }
+        entity.setDurationMinutes(dto.durationMinutes);
+        entity.setBufferMinutes(dto.bufferMinutes);
+        entity.setMaxPerSlot(dto.maxPerSlot);
+    }
+}

--- a/backend/bot/src/main/java/com/whatsbot/booking/management/model/Appointment.java
+++ b/backend/bot/src/main/java/com/whatsbot/booking/management/model/Appointment.java
@@ -1,0 +1,46 @@
+package com.whatsbot.booking.management.model;
+
+import com.whatsbot.auth.model.Tenant;
+import com.whatsbot.user.model.User;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "appointments")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Appointment {
+    @Id
+    @GeneratedValue
+    private UUID id;
+
+    @ManyToOne(optional = false)
+    private Tenant tenant;
+
+    @ManyToOne(optional = false)
+    private User user;
+
+    @ManyToOne(optional = false)
+    private ServiceOffering service;
+
+    @Column(nullable = false)
+    private LocalDate date;
+
+    @Column(nullable = false)
+    private LocalTime time;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private AppointmentStatus status;
+
+    @CreationTimestamp
+    private Instant createdAt;
+}

--- a/backend/bot/src/main/java/com/whatsbot/booking/management/model/AppointmentStatus.java
+++ b/backend/bot/src/main/java/com/whatsbot/booking/management/model/AppointmentStatus.java
@@ -1,0 +1,7 @@
+package com.whatsbot.booking.management.model;
+
+public enum AppointmentStatus {
+    PENDING,
+    CONFIRMED,
+    CANCELLED
+}

--- a/backend/bot/src/main/java/com/whatsbot/booking/management/model/Availability.java
+++ b/backend/bot/src/main/java/com/whatsbot/booking/management/model/Availability.java
@@ -1,0 +1,34 @@
+package com.whatsbot.booking.management.model;
+
+import com.whatsbot.auth.model.Tenant;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "availabilities")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Availability {
+    @Id
+    @GeneratedValue
+    private UUID id;
+
+    @ManyToOne(optional = false)
+    private Tenant tenant;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private DayOfWeek dayOfWeek;
+
+    @Column(nullable = false)
+    private LocalTime startTime;
+
+    @Column(nullable = false)
+    private LocalTime endTime;
+}

--- a/backend/bot/src/main/java/com/whatsbot/booking/management/model/BookingNotification.java
+++ b/backend/bot/src/main/java/com/whatsbot/booking/management/model/BookingNotification.java
@@ -1,0 +1,30 @@
+package com.whatsbot.booking.management.model;
+
+import com.whatsbot.auth.model.Tenant;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "booking_notifications")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class BookingNotification {
+    @Id
+    @GeneratedValue
+    private UUID id;
+
+    @ManyToOne(optional = false)
+    private Tenant tenant;
+
+    @Column(nullable = false)
+    private String message;
+
+    @CreationTimestamp
+    private Instant createdAt;
+}

--- a/backend/bot/src/main/java/com/whatsbot/booking/management/model/ServiceOffering.java
+++ b/backend/bot/src/main/java/com/whatsbot/booking/management/model/ServiceOffering.java
@@ -1,0 +1,29 @@
+package com.whatsbot.booking.management.model;
+
+import com.whatsbot.auth.model.Tenant;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "services")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ServiceOffering {
+    @Id
+    @GeneratedValue
+    private UUID id;
+
+    @ManyToOne(optional = false)
+    private Tenant tenant;
+
+    @Column(nullable = false)
+    private String name;
+
+    private int durationMinutes;
+    private int bufferMinutes;
+    private int maxPerSlot;
+}

--- a/backend/bot/src/main/java/com/whatsbot/booking/management/notification/NotificationService.java
+++ b/backend/bot/src/main/java/com/whatsbot/booking/management/notification/NotificationService.java
@@ -1,0 +1,7 @@
+package com.whatsbot.booking.management.notification;
+
+import com.whatsbot.booking.management.model.BookingNotification;
+
+public interface NotificationService {
+    void notify(BookingNotification notification);
+}

--- a/backend/bot/src/main/java/com/whatsbot/booking/management/notification/NotificationServiceImpl.java
+++ b/backend/bot/src/main/java/com/whatsbot/booking/management/notification/NotificationServiceImpl.java
@@ -1,0 +1,22 @@
+package com.whatsbot.booking.management.notification;
+
+import com.whatsbot.booking.management.model.BookingNotification;
+import com.whatsbot.booking.management.repository.BookingNotificationRepository;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationServiceImpl implements NotificationService {
+
+    private static final Logger log = LoggerFactory.getLogger(NotificationServiceImpl.class);
+    private final BookingNotificationRepository repository;
+
+    @Override
+    public void notify(BookingNotification notification) {
+        repository.save(notification);
+        log.info("New notification for tenant {}: {}", notification.getTenant().getId(), notification.getMessage());
+    }
+}

--- a/backend/bot/src/main/java/com/whatsbot/booking/management/repository/AppointmentRepository.java
+++ b/backend/bot/src/main/java/com/whatsbot/booking/management/repository/AppointmentRepository.java
@@ -1,0 +1,20 @@
+package com.whatsbot.booking.management.repository;
+
+import com.whatsbot.auth.model.Tenant;
+import com.whatsbot.booking.management.model.Appointment;
+import com.whatsbot.booking.management.model.AppointmentStatus;
+import com.whatsbot.booking.management.model.ServiceOffering;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+public interface AppointmentRepository extends JpaRepository<Appointment, UUID> {
+    List<Appointment> findByTenantAndServiceAndDate(Tenant tenant, ServiceOffering service, LocalDate date);
+    List<Appointment> findByTenantAndStatus(Tenant tenant, AppointmentStatus status);
+    boolean existsByTenantAndServiceAndDateAndTime(Tenant tenant, ServiceOffering service, LocalDate date, LocalTime time);
+}

--- a/backend/bot/src/main/java/com/whatsbot/booking/management/repository/AvailabilityRepository.java
+++ b/backend/bot/src/main/java/com/whatsbot/booking/management/repository/AvailabilityRepository.java
@@ -1,0 +1,15 @@
+package com.whatsbot.booking.management.repository;
+
+import com.whatsbot.auth.model.Tenant;
+import com.whatsbot.booking.management.model.Availability;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.DayOfWeek;
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+public interface AvailabilityRepository extends JpaRepository<Availability, UUID> {
+    List<Availability> findByTenantAndDayOfWeek(Tenant tenant, DayOfWeek dayOfWeek);
+}

--- a/backend/bot/src/main/java/com/whatsbot/booking/management/repository/BookingNotificationRepository.java
+++ b/backend/bot/src/main/java/com/whatsbot/booking/management/repository/BookingNotificationRepository.java
@@ -1,0 +1,14 @@
+package com.whatsbot.booking.management.repository;
+
+import com.whatsbot.auth.model.Tenant;
+import com.whatsbot.booking.management.model.BookingNotification;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+public interface BookingNotificationRepository extends JpaRepository<BookingNotification, UUID> {
+    List<BookingNotification> findByTenantOrderByCreatedAtDesc(Tenant tenant);
+}

--- a/backend/bot/src/main/java/com/whatsbot/booking/management/repository/ServiceOfferingRepository.java
+++ b/backend/bot/src/main/java/com/whatsbot/booking/management/repository/ServiceOfferingRepository.java
@@ -1,0 +1,14 @@
+package com.whatsbot.booking.management.repository;
+
+import com.whatsbot.auth.model.Tenant;
+import com.whatsbot.booking.management.model.ServiceOffering;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+public interface ServiceOfferingRepository extends JpaRepository<ServiceOffering, UUID> {
+    List<ServiceOffering> findByTenant(Tenant tenant);
+}

--- a/backend/bot/src/main/java/com/whatsbot/booking/management/service/AvailabilityService.java
+++ b/backend/bot/src/main/java/com/whatsbot/booking/management/service/AvailabilityService.java
@@ -1,0 +1,13 @@
+package com.whatsbot.booking.management.service;
+
+import com.whatsbot.booking.management.dto.AvailabilityDto;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface AvailabilityService {
+    List<AvailabilityDto> list();
+    AvailabilityDto create(AvailabilityDto dto);
+    AvailabilityDto update(UUID id, AvailabilityDto dto);
+    void delete(UUID id);
+}

--- a/backend/bot/src/main/java/com/whatsbot/booking/management/service/BookingManager.java
+++ b/backend/bot/src/main/java/com/whatsbot/booking/management/service/BookingManager.java
@@ -1,0 +1,15 @@
+package com.whatsbot.booking.management.service;
+
+import com.whatsbot.booking.management.dto.AppointmentDto;
+import com.whatsbot.booking.management.dto.SlotDto;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+public interface BookingManager {
+    AppointmentDto create(UUID userId, UUID serviceId, LocalDate date, String time);
+    List<SlotDto> availableSlots(UUID serviceId, LocalDate date);
+    List<AppointmentDto> pending();
+    void approve(UUID bookingId);
+}

--- a/backend/bot/src/main/java/com/whatsbot/booking/management/service/ServiceOfferingService.java
+++ b/backend/bot/src/main/java/com/whatsbot/booking/management/service/ServiceOfferingService.java
@@ -1,0 +1,13 @@
+package com.whatsbot.booking.management.service;
+
+import com.whatsbot.booking.management.dto.ServiceDto;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface ServiceOfferingService {
+    List<ServiceDto> list();
+    ServiceDto create(ServiceDto dto);
+    ServiceDto update(UUID id, ServiceDto dto);
+    void delete(UUID id);
+}

--- a/backend/bot/src/main/java/com/whatsbot/booking/management/service/impl/AvailabilityServiceImpl.java
+++ b/backend/bot/src/main/java/com/whatsbot/booking/management/service/impl/AvailabilityServiceImpl.java
@@ -1,0 +1,58 @@
+package com.whatsbot.booking.management.service.impl;
+
+import com.whatsbot.auth.middleware.TenantContext;
+import com.whatsbot.auth.repository.TenantRepository;
+import com.whatsbot.booking.management.dto.AvailabilityDto;
+import com.whatsbot.booking.management.mapper.AvailabilityMapper;
+import com.whatsbot.booking.management.model.Availability;
+import com.whatsbot.booking.management.repository.AvailabilityRepository;
+import com.whatsbot.booking.management.service.AvailabilityService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class AvailabilityServiceImpl implements AvailabilityService {
+
+    private final TenantRepository tenantRepository;
+    private final AvailabilityRepository repository;
+    private final AvailabilityMapper mapper;
+
+    private com.whatsbot.auth.model.Tenant tenant() {
+        return tenantRepository.findById(TenantContext.get()).orElseThrow();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<AvailabilityDto> list() {
+        return repository.findAll().stream()
+                .filter(a -> a.getTenant().getId().equals(tenant().getId()))
+                .map(mapper::toDto).toList();
+    }
+
+    @Override
+    @Transactional
+    public AvailabilityDto create(AvailabilityDto dto) {
+        Availability entity = mapper.toEntity(dto);
+        entity.setTenant(tenant());
+        return mapper.toDto(repository.save(entity));
+    }
+
+    @Override
+    @Transactional
+    public AvailabilityDto update(UUID id, AvailabilityDto dto) {
+        Availability entity = repository.findById(id).orElseThrow();
+        mapper.update(dto, entity);
+        return mapper.toDto(repository.save(entity));
+    }
+
+    @Override
+    @Transactional
+    public void delete(UUID id) {
+        repository.deleteById(id);
+    }
+}

--- a/backend/bot/src/main/java/com/whatsbot/booking/management/service/impl/BookingManagerImpl.java
+++ b/backend/bot/src/main/java/com/whatsbot/booking/management/service/impl/BookingManagerImpl.java
@@ -1,0 +1,110 @@
+package com.whatsbot.booking.management.service.impl;
+
+import com.whatsbot.auth.middleware.TenantContext;
+import com.whatsbot.auth.model.Tenant;
+import com.whatsbot.auth.repository.TenantRepository;
+import com.whatsbot.booking.management.dto.AppointmentDto;
+import com.whatsbot.booking.management.dto.SlotDto;
+import com.whatsbot.booking.management.mapper.AppointmentMapper;
+import com.whatsbot.booking.management.model.*;
+import com.whatsbot.booking.management.repository.*;
+import com.whatsbot.booking.management.service.BookingManager;
+import com.whatsbot.user.model.User;
+import com.whatsbot.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class BookingManagerImpl implements BookingManager {
+
+    private final TenantRepository tenantRepository;
+    private final ServiceOfferingRepository serviceRepository;
+    private final AvailabilityRepository availabilityRepository;
+    private final AppointmentRepository appointmentRepository;
+    private final BookingNotificationRepository notificationRepository;
+    private final UserRepository userRepository;
+    private final AppointmentMapper appointmentMapper;
+
+    private Tenant currentTenant() {
+        UUID id = TenantContext.get();
+        return tenantRepository.findById(id).orElseThrow();
+    }
+
+    @Override
+    @Transactional
+    public AppointmentDto create(UUID userId, UUID serviceId, LocalDate date, String timeStr) {
+        Tenant tenant = currentTenant();
+        ServiceOffering service = serviceRepository.findById(serviceId).orElseThrow();
+        User user = userRepository.findById(userId).orElseThrow();
+        LocalTime time = LocalTime.parse(timeStr);
+
+        if (appointmentRepository.existsByTenantAndServiceAndDateAndTime(tenant, service, date, time)) {
+            throw new IllegalStateException("Slot already booked");
+        }
+
+        Appointment appointment = new Appointment();
+        appointment.setTenant(tenant);
+        appointment.setUser(user);
+        appointment.setService(service);
+        appointment.setDate(date);
+        appointment.setTime(time);
+        appointment.setStatus(AppointmentStatus.PENDING);
+        appointment = appointmentRepository.save(appointment);
+
+        notificationRepository.save(new BookingNotification(null, tenant, "New booking request", null));
+        return appointmentMapper.toDto(appointment);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<SlotDto> availableSlots(UUID serviceId, LocalDate date) {
+        Tenant tenant = currentTenant();
+        ServiceOffering service = serviceRepository.findById(serviceId).orElseThrow();
+        List<Availability> avail = availabilityRepository.findByTenantAndDayOfWeek(tenant, date.getDayOfWeek());
+        List<Appointment> bookings = appointmentRepository.findByTenantAndServiceAndDate(tenant, service, date);
+        List<SlotDto> slots = new ArrayList<>();
+        for (Availability a : avail) {
+            LocalTime t = a.getStartTime();
+            while (!t.plusMinutes(service.getDurationMinutes()).isAfter(a.getEndTime())) {
+                int booked = (int) bookings.stream().filter(b -> b.getTime().equals(t)).count();
+                int remaining = service.getMaxPerSlot() - booked;
+                if (remaining > 0) {
+                    SlotDto dto = new SlotDto();
+                    dto.time = t.toString();
+                    dto.remaining = remaining;
+                    slots.add(dto);
+                }
+                t = t.plusMinutes(service.getDurationMinutes() + service.getBufferMinutes());
+            }
+        }
+        return slots;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<AppointmentDto> pending() {
+        Tenant tenant = currentTenant();
+        return appointmentRepository.findByTenantAndStatus(tenant, AppointmentStatus.PENDING)
+                .stream().map(appointmentMapper::toDto).toList();
+    }
+
+    @Override
+    @Transactional
+    public void approve(UUID bookingId) {
+        Tenant tenant = currentTenant();
+        Appointment app = appointmentRepository.findById(bookingId).orElseThrow();
+        if (!app.getTenant().getId().equals(tenant.getId())) {
+            throw new IllegalArgumentException("Invalid tenant");
+        }
+        app.setStatus(AppointmentStatus.CONFIRMED);
+        appointmentRepository.save(app);
+    }
+}

--- a/backend/bot/src/main/java/com/whatsbot/booking/management/service/impl/ServiceOfferingServiceImpl.java
+++ b/backend/bot/src/main/java/com/whatsbot/booking/management/service/impl/ServiceOfferingServiceImpl.java
@@ -1,0 +1,56 @@
+package com.whatsbot.booking.management.service.impl;
+
+import com.whatsbot.auth.middleware.TenantContext;
+import com.whatsbot.auth.repository.TenantRepository;
+import com.whatsbot.booking.management.dto.ServiceDto;
+import com.whatsbot.booking.management.mapper.ServiceMapper;
+import com.whatsbot.booking.management.model.ServiceOffering;
+import com.whatsbot.booking.management.repository.ServiceOfferingRepository;
+import com.whatsbot.booking.management.service.ServiceOfferingService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class ServiceOfferingServiceImpl implements ServiceOfferingService {
+
+    private final TenantRepository tenantRepository;
+    private final ServiceOfferingRepository repository;
+    private final ServiceMapper mapper;
+
+    private com.whatsbot.auth.model.Tenant tenant() {
+        return tenantRepository.findById(TenantContext.get()).orElseThrow();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<ServiceDto> list() {
+        return repository.findByTenant(tenant()).stream().map(mapper::toDto).toList();
+    }
+
+    @Override
+    @Transactional
+    public ServiceDto create(ServiceDto dto) {
+        ServiceOffering entity = mapper.toEntity(dto);
+        entity.setTenant(tenant());
+        return mapper.toDto(repository.save(entity));
+    }
+
+    @Override
+    @Transactional
+    public ServiceDto update(UUID id, ServiceDto dto) {
+        ServiceOffering entity = repository.findById(id).orElseThrow();
+        mapper.update(dto, entity);
+        return mapper.toDto(repository.save(entity));
+    }
+
+    @Override
+    @Transactional
+    public void delete(UUID id) {
+        repository.deleteById(id);
+    }
+}

--- a/backend/bot/src/test/java/com/whatsbot/booking/BookingManagerTest.java
+++ b/backend/bot/src/test/java/com/whatsbot/booking/BookingManagerTest.java
@@ -1,0 +1,28 @@
+package com.whatsbot.booking;
+
+import com.whatsbot.booking.management.service.BookingManager;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class BookingManagerTest {
+
+    @Autowired
+    private BookingManager bookingManager;
+
+    @Test
+    void slotsNotEmpty() {
+        var tenantId = UUID.randomUUID();
+        // assuming data initializer created demo data
+        var slots = bookingManager.availableSlots(
+                bookingManager.pending().stream().findFirst().map(b -> b.serviceId).orElse(null),
+                LocalDate.now());
+        assertThat(slots).isNotNull();
+    }
+}

--- a/frontend/src/components/booking/BookingDashboard.tsx
+++ b/frontend/src/components/booking/BookingDashboard.tsx
@@ -1,0 +1,32 @@
+import { useEffect, useState } from 'react';
+import useBooking from '../../hooks/booking/useBooking';
+
+export default function BookingDashboard() {
+  const booking = useBooking();
+  const [items, setItems] = useState([] as any[]);
+
+  const load = () => {
+    booking.pending().then(setItems);
+  };
+  useEffect(load, []);
+
+  const approve = (id: string) => {
+    booking.approve(id).then(load);
+  };
+
+  return (
+    <div>
+      <h3>Prenotazioni in attesa</h3>
+      <ul className="list-group">
+        {items.map((b) => (
+          <li key={b.id} className="list-group-item d-flex justify-content-between">
+            {b.date} {b.time}
+            <button className="btn btn-sm btn-success" onClick={() => approve(b.id)}>
+              Approva
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/components/booking/BookingForm.tsx
+++ b/frontend/src/components/booking/BookingForm.tsx
@@ -1,0 +1,49 @@
+import { useState } from 'react';
+import useServices from '../../hooks/booking/useServices';
+import useBooking from '../../hooks/booking/useBooking';
+import CalendarView from './CalendarView';
+
+interface Props {
+  userId: string;
+}
+
+export default function BookingForm({ userId }: Props) {
+  const { services } = useServices();
+  const booking = useBooking();
+  const [serviceId, setServiceId] = useState('');
+  const [time, setTime] = useState('');
+  const [date, setDate] = useState('');
+
+  const submit = () => {
+    booking.create({ userId, serviceId, date, time }).then(() => alert('Richiesta inviata'));
+  };
+
+  return (
+    <div>
+      <select className="form-select mb-2" value={serviceId} onChange={(e) => setServiceId(e.target.value)}>
+        <option value="">Seleziona servizio</option>
+        {services.map((s) => (
+          <option key={s.id} value={s.id}>
+            {s.name}
+          </option>
+        ))}
+      </select>
+      {serviceId && (
+        <div>
+          <CalendarView
+            serviceId={serviceId}
+            onSelect={(d, t) => {
+              setDate(d);
+              setTime(t);
+            }}
+          />
+        </div>
+      )}
+      {time && (
+        <button className="btn btn-primary mt-2" onClick={submit}>
+          Prenota {date} {time}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/booking/CalendarView.tsx
+++ b/frontend/src/components/booking/CalendarView.tsx
@@ -1,0 +1,34 @@
+import { useState } from 'react';
+import useSlots from '../../hooks/booking/useSlots';
+
+interface Props {
+  serviceId: string;
+  onSelect: (date: string, time: string) => void;
+}
+
+export default function CalendarView({ serviceId, onSelect }: Props) {
+  const [date, setDate] = useState('');
+  const slots = useSlots(serviceId, date);
+
+  return (
+    <div>
+      <input
+        type="date"
+        className="form-control mb-2"
+        value={date}
+        onChange={(e) => setDate(e.target.value)}
+      />
+      <div className="d-flex flex-wrap gap-2">
+        {slots.map((s) => (
+          <button
+            key={s.time}
+            className="btn btn-outline-primary"
+            onClick={() => onSelect(date, s.time)}
+          >
+            {s.time} ({s.remaining})
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/booking/ServiceEditor.tsx
+++ b/frontend/src/components/booking/ServiceEditor.tsx
@@ -1,0 +1,29 @@
+import { useState } from 'react';
+import useServices from '../../hooks/booking/useServices';
+
+export default function ServiceEditor() {
+  const { services, create } = useServices();
+  const [name, setName] = useState('');
+
+  const add = () => {
+    create({ name, durationMinutes: 30, bufferMinutes: 10, maxPerSlot: 1 }).then(() => setName(''));
+  };
+
+  return (
+    <div>
+      <div className="input-group mb-2">
+        <input className="form-control" value={name} onChange={(e) => setName(e.target.value)} />
+        <button className="btn btn-primary" onClick={add} disabled={!name}>
+          Aggiungi
+        </button>
+      </div>
+      <ul className="list-group">
+        {services.map((s) => (
+          <li key={s.id} className="list-group-item">
+            {s.name}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/hooks/booking/useBooking.ts
+++ b/frontend/src/hooks/booking/useBooking.ts
@@ -1,0 +1,9 @@
+import api from '../../api';
+import { Booking } from '../../types';
+
+export default function useBooking() {
+  const create = (body: any) => api.post<Booking>('/booking/create', body);
+  const approve = (id: string) => api.post('/booking/approve', { bookingId: id });
+  const pending = () => api.get<Booking[]>('/booking/pending').then((r) => r.data);
+  return { create, approve, pending };
+}

--- a/frontend/src/hooks/booking/useServices.ts
+++ b/frontend/src/hooks/booking/useServices.ts
@@ -1,0 +1,13 @@
+import { useEffect, useState } from 'react';
+import api from '../../api';
+import { ServiceItem } from '../../types';
+
+export default function useServices() {
+  const [services, setServices] = useState<ServiceItem[]>([]);
+  const load = () => {
+    api.get<ServiceItem[]>('/admin/booking/services').then((r) => setServices(r.data));
+  };
+  useEffect(load, []);
+  const create = (s: Partial<ServiceItem>) => api.post('/admin/booking/services', s).then(load);
+  return { services, reload: load, create };
+}

--- a/frontend/src/hooks/booking/useSlots.ts
+++ b/frontend/src/hooks/booking/useSlots.ts
@@ -1,0 +1,15 @@
+import { useEffect, useState } from 'react';
+import api from '../../api';
+import { Slot } from '../../types';
+
+export default function useSlots(serviceId: string, date: string) {
+  const [slots, setSlots] = useState<Slot[]>([]);
+  useEffect(() => {
+    if (serviceId && date) {
+      api
+        .get<Slot[]>(`/booking/slots?serviceId=${serviceId}&date=${date}`)
+        .then((r) => setSlots(r.data));
+    }
+  }, [serviceId, date]);
+  return slots;
+}

--- a/frontend/src/pages/AdminBookingPage.tsx
+++ b/frontend/src/pages/AdminBookingPage.tsx
@@ -1,0 +1,12 @@
+import BookingDashboard from '../components/booking/BookingDashboard';
+import ServiceEditor from '../components/booking/ServiceEditor';
+
+export default function AdminBookingPage() {
+  return (
+    <div className="container mt-3">
+      <h2>Gestione Prenotazioni</h2>
+      <ServiceEditor />
+      <BookingDashboard />
+    </div>
+  );
+}

--- a/frontend/src/pages/BookingPage.tsx
+++ b/frontend/src/pages/BookingPage.tsx
@@ -1,0 +1,11 @@
+import BookingForm from '../components/booking/BookingForm';
+
+export default function BookingPage() {
+  const userId = localStorage.getItem('userId') || '';
+  return (
+    <div className="container mt-3">
+      <h2>Prenota un servizio</h2>
+      <BookingForm userId={userId} />
+    </div>
+  );
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -46,3 +46,25 @@ export interface LoginRequest {
 export interface LoginResponse {
   token: string;
 }
+
+export interface ServiceItem {
+  id: string;
+  name: string;
+  durationMinutes: number;
+  bufferMinutes: number;
+  maxPerSlot: number;
+}
+
+export interface Slot {
+  time: string;
+  remaining: number;
+}
+
+export interface Booking {
+  id: string;
+  userId: string;
+  serviceId: string;
+  date: string;
+  time: string;
+  status: string;
+}


### PR DESCRIPTION
## Summary
- add MapStruct and configure Maven
- introduce booking management entities and repositories
- create booking service layer with slot calculation and approval
- expose CRUD endpoints for services, availability and bookings
- seed demo booking data
- provide React hooks and components for booking UI
- add initial JUnit test skeleton
- replace MapStruct usage with manual mappers as per policy

## Testing
- `mvn -q test` *(fails: command not found)*
- `npm test --silent` *(fails: vitest not found)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_685a9f180d90832ab3eb8787d913e717