### PR TITLE
Implement basic user registration

### DIFF
--- a/backend/bot/src/main/java/com/whatsbot/auth/DataInitializer.java
+++ b/backend/bot/src/main/java/com/whatsbot/auth/DataInitializer.java
@@ -27,14 +27,20 @@ public class DataInitializer implements CommandLineRunner {
         Tenant tenant = new Tenant(null, "demo");
         tenant = tenantRepository.save(tenant);
 
-        Role role = new Role(null, "SUPER_ADMIN", Set.of());
-        role = roleRepository.save(role);
+        Role superAdmin = new Role(null, "SUPER_ADMIN", Set.of());
+        superAdmin = roleRepository.save(superAdmin);
+
+        Role tenantAdmin = new Role(null, "TENANT_ADMIN", Set.of());
+        tenantAdmin = roleRepository.save(tenantAdmin);
+
+        Role userRole = new Role(null, "USER", Set.of());
+        userRole = roleRepository.save(userRole);
 
         AuthUser admin = new AuthUser();
         admin.setUsername("admin");
         admin.setPassword(passwordEncoder.encode("admin"));
         admin.setTenant(tenant);
-        admin.setRoles(Set.of(role));
+        admin.setRoles(Set.of(superAdmin));
         userRepository.save(admin);
     }
 }

--- a/backend/bot/src/main/java/com/whatsbot/auth/config/SecurityConfig.java
+++ b/backend/bot/src/main/java/com/whatsbot/auth/config/SecurityConfig.java
@@ -30,9 +30,9 @@ public class SecurityConfig {
                         .requestMatchers("/api/auth/**").permitAll()
                         .requestMatchers("/api/onboarding/**").permitAll()//TODO remove
                         .anyRequest().authenticated())
-                .sessionManagement(man -> man.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
-//                .addFilterBefore(new JwtAuthFilter(jwtService, userDetailsService), UsernamePasswordAuthenticationFilter.class)
-//                .addFilterAfter(new TenantFilter(jwtService), JwtAuthFilter.class);
+                .sessionManagement(man -> man.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .addFilterBefore(new JwtAuthFilter(jwtService, userDetailsService), UsernamePasswordAuthenticationFilter.class)
+                .addFilterAfter(new TenantFilter(jwtService), JwtAuthFilter.class);
         return http.build();
     }
 

--- a/backend/bot/src/main/java/com/whatsbot/auth/controller/AuthController.java
+++ b/backend/bot/src/main/java/com/whatsbot/auth/controller/AuthController.java
@@ -2,6 +2,8 @@ package com.whatsbot.auth.controller;
 
 import com.whatsbot.auth.dto.LoginRequest;
 import com.whatsbot.auth.dto.LoginResponse;
+import com.whatsbot.auth.dto.RegisterRequest;
+import com.whatsbot.auth.dto.RoleDto;
 import com.whatsbot.auth.dto.UserDto;
 import com.whatsbot.auth.service.AuthService;
 import com.whatsbot.auth.middleware.TenantContext;
@@ -22,9 +24,19 @@ public class AuthController {
         return authService.login(request);
     }
 
+    @PostMapping("/register")
+    public LoginResponse register(@RequestBody RegisterRequest request) {
+        return authService.register(request);
+    }
+
     @GetMapping("/me")
     public UserDto me(Authentication authentication) {
         UUID tenantId = TenantContext.get();
         return authService.currentUser(authentication.getName(), tenantId);
+    }
+
+    @GetMapping("/roles")
+    public java.util.List<RoleDto> roles() {
+        return authService.listRoles();
     }
 }

--- a/backend/bot/src/main/java/com/whatsbot/auth/dto/RegisterRequest.java
+++ b/backend/bot/src/main/java/com/whatsbot/auth/dto/RegisterRequest.java
@@ -1,0 +1,3 @@
+package com.whatsbot.auth.dto;
+
+public record RegisterRequest(String username, String password, String tenant) {}

--- a/backend/bot/src/main/java/com/whatsbot/auth/dto/RoleDto.java
+++ b/backend/bot/src/main/java/com/whatsbot/auth/dto/RoleDto.java
@@ -1,0 +1,5 @@
+package com.whatsbot.auth.dto;
+
+import java.util.UUID;
+
+public record RoleDto(UUID id, String name) {}

--- a/backend/bot/src/main/java/com/whatsbot/auth/mapper/RoleMapper.java
+++ b/backend/bot/src/main/java/com/whatsbot/auth/mapper/RoleMapper.java
@@ -1,0 +1,15 @@
+package com.whatsbot.auth.mapper;
+
+import com.whatsbot.auth.dto.RoleDto;
+import com.whatsbot.auth.model.Role;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RoleMapper {
+    public RoleDto toDto(Role role) {
+        if (role == null) {
+            return null;
+        }
+        return new RoleDto(role.getId(), role.getName());
+    }
+}

--- a/backend/bot/src/main/java/com/whatsbot/auth/repository/RoleRepository.java
+++ b/backend/bot/src/main/java/com/whatsbot/auth/repository/RoleRepository.java
@@ -4,8 +4,10 @@ import com.whatsbot.auth.model.Role;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 @Repository
 public interface RoleRepository extends JpaRepository<Role, UUID> {
+    Optional<Role> findByName(String name);
 }

--- a/backend/bot/src/main/java/com/whatsbot/auth/service/AuthService.java
+++ b/backend/bot/src/main/java/com/whatsbot/auth/service/AuthService.java
@@ -2,16 +2,25 @@ package com.whatsbot.auth.service;
 
 import com.whatsbot.auth.dto.LoginRequest;
 import com.whatsbot.auth.dto.LoginResponse;
+import com.whatsbot.auth.dto.RegisterRequest;
+import com.whatsbot.auth.dto.RoleDto;
 import com.whatsbot.auth.dto.UserDto;
 import com.whatsbot.auth.exception.AuthException;
 import com.whatsbot.auth.exception.UnauthorizedException;
 import com.whatsbot.auth.mapper.AuthUserMapper;
+import com.whatsbot.auth.mapper.RoleMapper;
 import com.whatsbot.auth.model.AuthUser;
+import com.whatsbot.auth.model.Role;
+import com.whatsbot.auth.model.Tenant;
 import com.whatsbot.auth.repository.AuthUserRepository;
+import com.whatsbot.auth.repository.RoleRepository;
+import com.whatsbot.auth.repository.TenantRepository;
 import com.whatsbot.auth.security.JwtService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 @Service
@@ -22,6 +31,9 @@ public class AuthService {
     private final PasswordEncoder passwordEncoder;
     private final JwtService jwtService;
     private final AuthUserMapper mapper;
+    private final RoleMapper roleMapper;
+    private final RoleRepository roleRepository;
+    private final TenantRepository tenantRepository;
 
     public LoginResponse login(LoginRequest request) {
         AuthUser user = userRepository.findByUsernameAndTenant_Name(request.username(), request.tenant())
@@ -31,6 +43,32 @@ public class AuthService {
         }
         String token = jwtService.generateToken(user.getId(), user.getUsername(), user.getTenant().getId());
         return new LoginResponse(token);
+    }
+
+    public LoginResponse register(RegisterRequest request) {
+        Tenant tenant = tenantRepository.findByName(request.tenant())
+                .orElseGet(() -> tenantRepository.save(new Tenant(null, request.tenant())));
+
+        if (userRepository.findByUsernameAndTenant_Name(request.username(), request.tenant()).isPresent()) {
+            throw new AuthException("User already exists");
+        }
+
+        Role role = roleRepository.findByName("USER")
+                .orElseThrow(() -> new AuthException("Role not found"));
+
+        AuthUser user = new AuthUser();
+        user.setUsername(request.username());
+        user.setPassword(passwordEncoder.encode(request.password()));
+        user.setTenant(tenant);
+        user.setRoles(Set.of(role));
+        user = userRepository.save(user);
+
+        String token = jwtService.generateToken(user.getId(), user.getUsername(), tenant.getId());
+        return new LoginResponse(token);
+    }
+
+    public List<RoleDto> listRoles() {
+        return roleRepository.findAll().stream().map(roleMapper::toDto).toList();
     }
 
     public UserDto currentUser(String username, UUID tenantId) {

--- a/frontend/src/auth/api/auth.ts
+++ b/frontend/src/auth/api/auth.ts
@@ -1,12 +1,22 @@
 import api from '../../api';
-import { LoginRequest, LoginResponse } from '../../types';
+import { LoginRequest, LoginResponse, RegisterRequest, Role } from '../../types';
 
 export async function login(body: LoginRequest): Promise<LoginResponse> {
   const { data } = await api.post<LoginResponse>('/api/auth/login', body);
   return data;
 }
 
+export async function register(body: RegisterRequest): Promise<LoginResponse> {
+  const { data } = await api.post<LoginResponse>('/api/auth/register', body);
+  return data;
+}
+
 export async function me() {
   const { data } = await api.get('/api/auth/me');
+  return data;
+}
+
+export async function getRoles() {
+  const { data } = await api.get<Role[]>('/api/auth/roles');
   return data;
 }

--- a/frontend/src/auth/hooks/useRegister.ts
+++ b/frontend/src/auth/hooks/useRegister.ts
@@ -1,0 +1,20 @@
+import { useState } from 'react';
+import { register as registerApi } from '../api/auth';
+import { RegisterRequest } from '../../types';
+import useAuth from './useAuth';
+
+export default function useRegister() {
+  const auth = useAuth();
+  const [error, setError] = useState('');
+
+  const register = async (req: RegisterRequest) => {
+    try {
+      const res = await registerApi(req);
+      auth.login(res.token);
+    } catch {
+      setError('Registrazione non riuscita');
+    }
+  };
+
+  return { register, error };
+}

--- a/frontend/src/auth/pages/RegisterPage.tsx
+++ b/frontend/src/auth/pages/RegisterPage.tsx
@@ -1,0 +1,50 @@
+import React, { FormEvent, useState } from 'react';
+import useRegister from '../hooks/useRegister';
+import { useNavigate } from 'react-router-dom';
+
+export default function RegisterPage() {
+  const { register, error } = useRegister();
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [tenant, setTenant] = useState('');
+  const navigate = useNavigate();
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    await register({ username, password, tenant });
+    navigate('/dashboard');
+  };
+
+  return (
+    <div className="flex items-center justify-center min-h-screen">
+      <form onSubmit={handleSubmit} className="space-y-4 w-full max-w-sm">
+        <input
+          className="w-full border p-2 rounded"
+          placeholder="Tenant"
+          value={tenant}
+          onChange={(e) => setTenant(e.target.value)}
+          required
+        />
+        <input
+          className="w-full border p-2 rounded"
+          placeholder="Username"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+          required
+        />
+        <input
+          className="w-full border p-2 rounded"
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+        />
+        {error && <div className="text-red-600 text-sm">{error}</div>}
+        <button className="w-full bg-blue-600 text-white p-2 rounded" type="submit">
+          Register
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -4,6 +4,7 @@ import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import Landing from './pages/Landing';
 import OnboardPage from './pages/OnboardPage';
 import LoginPage from './auth/pages/LoginPage';
+import RegisterPage from './auth/pages/RegisterPage';
 import DashboardPage from './pages/DashboardPage';
 import RequireAuth from './auth/components/RequireAuth';
 import { AuthProvider } from './auth/hooks/useAuth';
@@ -13,6 +14,7 @@ const router = createBrowserRouter([
   { path: '/', element: <Landing /> },
   { path: '/onboard', element: <OnboardPage /> },
   { path: '/login', element: <LoginPage /> },
+  { path: '/register', element: <RegisterPage /> },
   { path: '/dashboard', element: (
       <RequireAuth>
         <DashboardPage />

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -47,6 +47,17 @@ export interface LoginResponse {
   token: string;
 }
 
+export interface RegisterRequest {
+  username: string;
+  password: string;
+  tenant: string;
+}
+
+export interface Role {
+  id: string;
+  name: string;
+}
+
 export interface ServiceItem {
   id: string;
   name: string;


### PR DESCRIPTION
## Summary
- create SUPER_ADMIN, TENANT_ADMIN and USER roles at startup
- allow user registration and JWT issuance
- expose role listing endpoint
- wire JWT and tenant filters in security config
- add React register page and hooks

## Testing
- `mvn test` *(fails: command not found)*
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685aa5ba7fb0832ab952c79f5522bff2